### PR TITLE
Add TOTP demo/fixes

### DIFF
--- a/docs/TOTP.md
+++ b/docs/TOTP.md
@@ -4,6 +4,8 @@
 
 Kinglet 1.4.0 introduces TOTP (Time-based One-Time Password) support for session elevation, implementing RFC 6238 for enhanced security on sensitive operations.
 
+Basic TOTP generation, verification, and session elevation are built into Kinglet. The secret-at-rest helpers `encrypt_totp_secret()` and `decrypt_totp_secret()` use `cryptography` on standard Python runtimes and fall back to the Workers Web Crypto API on Python Workers, so encrypted TOTP secret storage remains available in both environments.
+
 ## Key Components
 
 ### 1. OTP Provider Pattern

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,7 @@ Quick start examples for all Kinglet features.
 - **[secure_admin_example.py](secure_admin_example.py)** - JWT, geo-restrictions
 - **[authz_example.py](authz_example.py)** - Fine-grained authorization
 - **[totp_example.py](totp_example.py)** - Two-factor authentication
+- **[totp_workers_demo/](totp_workers_demo/)** - Workers deployment demo for auth and TOTP
 
 ### Email & Integrations
 - **[ses_email_example.py](ses_email_example.py)** - Amazon SES email

--- a/examples/basic_api.py
+++ b/examples/basic_api.py
@@ -71,16 +71,18 @@ async def register(request):
     data = await request.json()
 
     if not data.get("email"):
-        return Response.error(
-            "Email required",
+        return Response(
+            {
+                "error": "Email required",
+                "detail": "Please provide a valid email",
+                "request_id": request.request_id,
+            },
             status=400,
-            detail="Please provide a valid email",
-            request_id=request.request_id,
         )
 
-    return Response.json(
+    return Response(
         {"user_id": "123", "email": data["email"], "created": True},
-        request_id=request.request_id,
+        status=201,
     )
 
 
@@ -144,32 +146,38 @@ if __name__ == "__main__":
 
     # Test health check
     status, headers, body = client.request("GET", "/api/")
+    assert status == 200, body
     print(f"Health: {status} - {body}")
 
     # Test search with typed parameters
     status, headers, body = client.request(
         "GET", "/api/search?page=2&limit=5&active=true&tags=python"
     )
+    assert status == 200, body
     print(f"Search: {status} - {body}")
 
     # Test authenticated user lookup
     status, headers, body = client.request(
         "GET", "/api/users/42", headers={"Authorization": "Bearer user-token-123"}
     )
+    assert status == 200, body
     print(f"User: {status} - {body}")
 
     # Test registration
     status, headers, body = client.request(
         "POST", "/api/auth/register", json={"email": "test@example.com"}
     )
+    assert status == 201, body
     print(f"Register: {status} - {body}")
 
     # Test validation error
     status, headers, body = client.request("POST", "/api/auth/register", json={})
+    assert status == 400, body
     print(f"Error: {status} - {body}")
 
     # Test OpenAPI spec generation
     status, headers, body = client.request("GET", "/api/openapi.json")
+    assert status == 200, body
     print(f"\nOpenAPI Spec: {status}")
     if status == 200:
         import json
@@ -184,6 +192,7 @@ if __name__ == "__main__":
 
     # Test Swagger UI
     status, headers, body = client.request("GET", "/api/docs")
+    assert status == 200, body
     print(f"Swagger UI: {status} - {len(body)} chars")
 
     print("\n✅ All examples completed!")

--- a/examples/totp_example.py
+++ b/examples/totp_example.py
@@ -70,7 +70,8 @@ async def setup_totp(request):
     )
 
     # Generate QR code URL for scanning
-    email = user["claims"].get("email", f"user_{user_id}")
+    claims = user.get("claims", {})
+    email = claims.get("email", f"user_{user_id}")
     qr_url = generate_totp_qr_url(secret, email, "MyApp")
 
     return {
@@ -182,9 +183,14 @@ async def step_up_authentication(request):
         return Response({"error": "Invalid code"}, status=401)
 
     # Create elevated JWT with additional claims
+    claims = user.get("claims", {})
     elevated_token = create_elevated_jwt(
         user_id=user_id,
-        claims={**user["claims"], "elevated": True, "elevation_time": int(time.time())},
+        claims={
+            **claims,
+            "elevated": True,
+            "elevation_time": int(time.time()),
+        },
         secret=request.env.JWT_SECRET,
         expires_in=900,  # 15 minutes
     )
@@ -372,7 +378,6 @@ async def get_test_info(request):
 # ============================================
 
 import secrets
-import time
 
 
 def generate_id():

--- a/examples/totp_example.py
+++ b/examples/totp_example.py
@@ -3,6 +3,8 @@ TOTP Authentication Example
 Demonstrates session elevation with TOTP in Kinglet
 """
 
+import time
+
 from kinglet import Kinglet, Response
 from kinglet.authz import (
     configure_otp_provider,

--- a/examples/totp_workers_demo/README.md
+++ b/examples/totp_workers_demo/README.md
@@ -1,0 +1,37 @@
+# Kinglet TOTP Workers Demo
+
+Dedicated Cloudflare Workers project for exercising Kinglet auth and TOTP against the real runtime.
+
+This project is pinned to the local Kinglet working copy via an absolute `file:///...` dependency so `pywrangler` exports the code that is actually in this repository.
+
+## Run locally
+
+```bash
+rm -rf .venv-workers python_modules vendor
+uv lock --refresh
+uv sync --group dev --refresh-package kinglet --reinstall-package kinglet
+uv run pywrangler sync --force
+uv run pywrangler dev
+```
+
+## Deploy remotely
+
+```bash
+rm -rf .venv-workers python_modules vendor
+uv lock --refresh
+uv sync --group dev --refresh-package kinglet --reinstall-package kinglet
+uv run pywrangler sync --force
+uv run pywrangler deploy
+```
+
+Before deploying, inspect `python_modules/kinglet` and confirm it contains the local Kinglet source you expect. If it does not, stop there and fix the export state instead of deploying stale modules.
+
+Helper script: run `../../scripts/pywrangler-clean-deploy.sh` from this demo directory to execute the same forced-refresh workflow.
+
+## What this demo proves
+
+- `kinglet` imports without eager `cryptography` loading
+- JWT auth works in Workers
+- TOTP generation and verification work in Workers
+- TOTP secret encryption and decryption work in Workers
+- Elevated session checks work in Workers

--- a/examples/totp_workers_demo/pyproject.toml
+++ b/examples/totp_workers_demo/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "kinglet-totp-workers-demo"
+version = "0.1.0"
+description = "Workers deployment demo for Kinglet auth and TOTP"
+requires-python = ">=3.12"
+dependencies = [
+    "kinglet @ file:///Users/mitchellcurrie/Projects/Kinglet",
+]
+
+[dependency-groups]
+dev = [
+    "workers-py",
+]
+
+[build-system]
+requires = ["setuptools>=70", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/examples/totp_workers_demo/uv.lock
+++ b/examples/totp_workers_demo/uv.lock
@@ -1,0 +1,439 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bc/ee4137cbbe105652c0ee4252792b78fc8e7afa4b8e61d9d5dc05a7f45731/cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1", size = 8008324, upload-time = "2026-06-09T22:31:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/85/6379d42181bfc713094f081360fc5784d6c816b599d45e7f082502d173ce/cryptography-48.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225", size = 4696243, upload-time = "2026-06-09T22:32:33.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/87/c85d147b53323c7eb4d850920c8901377323c2a0ff8d79c262d4fee89aa2/cryptography-48.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d27a5696721ef7a672b8c810f6aded391058e0b9486e63e6d93baf765da691", size = 4713235, upload-time = "2026-06-09T22:31:40.141Z" },
+    { url = "https://files.pythonhosted.org/packages/79/58/67cbf8cf1ee7c54b439ca07bbecf8362c07afc11a3724fea70f745784add/cryptography-48.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb86ce1af36fe65041b6db9a8bb064ee621a7e5fded0f80d475ec243477cd242", size = 4702323, upload-time = "2026-06-09T22:31:42.191Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c6/24266ac10c47f6cd2a865f4446062b466da1d1f10b27189eac00e61bf0c9/cryptography-48.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b024e784ad6c077ee0147b35ea9cbfc1e34e1fd4c1dcca214c2794d73a12df08", size = 5300085, upload-time = "2026-06-09T22:31:58.703Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/bb/cc4b78784f97efc8c5874c2a9743708d172be6663024b34a0467885ae0c8/cryptography-48.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3752f2dbc8f07a30aad2932c986cea495b03bb554887828225da104f732852b6", size = 4746137, upload-time = "2026-06-09T22:31:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/52/0c44de3f5267f8fbe8e835138017522a333436166e406f0db9b9e6e3033f/cryptography-48.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:bd81490cd5801d755cf97bb68ac191f14b708470b1c7cf4580f669b9c9264cd8", size = 4333867, upload-time = "2026-06-09T22:32:28.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/2e/772d7adbfa931537bc401640b7cac9976bff689bda187833e5d63b428e49/cryptography-48.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:66fd0771e7b9c6dcd44cf1120690d2338d16d72795cf40cae2786a39eba65429", size = 4701805, upload-time = "2026-06-09T22:31:38.284Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a3/b06844f303873493c963caf581c04df31c7035e0c1b0f02c4814d319ec80/cryptography-48.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:3fd2ca57062b241c856670b073487d2e86c4637937ca5601e48f97bf8e11fc8f", size = 5258461, upload-time = "2026-06-09T22:31:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/13/8b765e2e12b07c74941caadb9d1c8fdc006c4dfbf2b8f2d610519758954d/cryptography-48.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:0ee6ea481db1ab889cba043ec1eda17bb9c1ea79db6722f779c3667f9f70322f", size = 4745488, upload-time = "2026-06-09T22:32:30.07Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/aa/48972bce55049b32a94f4907eda4d75fa385aad8a39506cc2fc72196ecf0/cryptography-48.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2ceef93cb096aa3c4cc4b5c94ca6131f9196d28c64d6111533402a9b2054d41", size = 4830256, upload-time = "2026-06-09T22:31:43.868Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a2/e5079a032fb85cf6005046ca92bbd78b0c82dad2b5751ab8c311659da06f/cryptography-48.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bd3f92d76217892b15df84ca256c2c113d386fdda7a7d8691aeeced976507c6", size = 4979117, upload-time = "2026-06-09T22:31:05.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/a0/8f50cae9c74e718ed769d63ed5c74bd0ea830c9550a74629cebd1b9c7bc7/cryptography-48.0.1-cp311-abi3-win32.whl", hash = "sha256:b9a32b876490d66c8bcc9963ef220199569748434ab01a9d6aaeabf88e7f5158", size = 3304154, upload-time = "2026-06-09T22:32:16.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/69/0572c77dbace6fef72f33755bd52ea399c71367250d366237f8691826b9e/cryptography-48.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:39489bfca54c7a1f6b297efcd8bc608ab92d16c4ca631b0cad4da46724588b24", size = 3817138, upload-time = "2026-06-09T22:32:00.388Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/3e768b4c3bc78201583fa35a0e18f640dd782ff41afba88f8545481a8874/cryptography-48.0.1-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:f817adc181390bd54f2f700107a7419040fb7c1bdf2fc26f36551a06a68c3345", size = 7989830, upload-time = "2026-06-09T22:31:07.8Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/13/6476736484b94041110c8340a3eb63962fea4975baea8cb4a512adb44d4d/cryptography-48.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d5d30989c6917b478b5817902e85fddaea2261efa8648383d965381ccb9e1ac4", size = 4689201, upload-time = "2026-06-09T22:31:09.745Z" },
+    { url = "https://files.pythonhosted.org/packages/79/62/65a87f34d2a431546e2509b85d55e8c90df86d668f6731da64d538512ac2/cryptography-48.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:df637c05205ea7c1d7fbcbe54bbfea648a52951155f997af13d895d0ecc96991", size = 4702822, upload-time = "2026-06-09T22:32:24.409Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/59/810b5204b0a9b10f4b6bc06bd551a8b609803cd931806bc3b71884b225e5/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:869c3b8a53bfe27147832df48b32adadf558249d50e76cb3769d40e986b13265", size = 4694875, upload-time = "2026-06-09T22:32:08.737Z" },
+    { url = "https://files.pythonhosted.org/packages/24/dc/d8ca05ffea724eec6d232ea6f18e74c269eb6bdfdcc9bfba689790d1325f/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:e361afba8918070d376df76f408a4f67fec0ee9cff81a99e48fe9a233ef59e17", size = 5290385, upload-time = "2026-06-09T22:31:15.212Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8c/3be6cb4da181f5bb6c19cf560c2359d60644a6b5fc5b57854e528f47b296/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d069066deead00ac7f090be101be875a06855908f7ec004c27b8fefb4acfb411", size = 4737082, upload-time = "2026-06-09T22:32:22.66Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/f6/d5f60a5a1434dbfd949e227fd0065d194c7e6b6ac526b17f5c06152b8231/cryptography-48.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:09f73a725d582cef64b91281a322cd798d14a33b2b6f2b7ad9531dc336d84c02", size = 4325328, upload-time = "2026-06-09T22:32:10.777Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b7/ba75dd947a14b6ad907b01ae8f6b5b348cdd1b48142f0063dee9e20c1d9d/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:15254441469dd6bf027039453288e2072124f8b6603563f5d759e1c9b69273fa", size = 4694530, upload-time = "2026-06-09T22:31:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/50d6b9e8aff12d8b67afaeb3569335e32dc83a5723e3bbded24fdac9f809/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:8ace4507d1e6533c125f4fac754f8bb8b6a74c08e92179dabd7e16571a3efbf3", size = 5245046, upload-time = "2026-06-09T22:31:25.774Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/04/618f4115cfc0add0838c82507aa18a346089428da8653ad38b3ff36f5cb3/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b4e391975f038e66432328639620a4aff2d307513b004f1ca06d6225bced815c", size = 4736660, upload-time = "2026-06-09T22:32:12.676Z" },
+    { url = "https://files.pythonhosted.org/packages/24/9c/06e062462a0de28a3b3911322eded4c16deb9f441b1b7575d3dc59488ab5/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:42fcd8e26fe555d9b3577a135f5091fefa0aa4e99129c23fb56787a1bd4ada72", size = 4822229, upload-time = "2026-06-09T22:31:17.062Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/be/0561971eaaee4b8a0e7d5113c536921063ab91aaf23278ac374eaf881e11/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c1400da5e32a43253392277eac7490a60e497d810a63dd5608d71bbd7af507c9", size = 4966364, upload-time = "2026-06-09T22:31:32.842Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/27/728c77876f12b000820b69ae490f3c4083775e79e07827e9e60be07ad209/cryptography-48.0.1-cp314-cp314t-win32.whl", hash = "sha256:0df56b056bc17c1b7d6821dfa65216e62bd232d8ab05eb3db44e71d235651471", size = 3278498, upload-time = "2026-06-09T22:31:29.154Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/79a612c6d7b1e6ee0edd43633d53035bec2cfb78c82b76f7864f39e36f34/cryptography-48.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:9de21387aa95e2a895823d0745b430bed4f33503ba9ab5e0b5311f33e37d66d2", size = 3798790, upload-time = "2026-06-09T22:31:56.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6c/00fa2a95997164c8b2072ce327c23d4ab20809ccc323ea5fab91e53a4bba/cryptography-48.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:4fdc69f8e4316bcf0c8c8ec1f26f285d12e8142d88d96c876a59a03be3f6ae67", size = 7987408, upload-time = "2026-06-09T22:32:20.777Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d9/45f309a7e4e5f3f8f121d6d3be9e94024a7726ec598d6e08ae04edb2f04d/cryptography-48.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48fe40804d4caa2288f24e70ca8c64c42dd826da0ad7e4f1b41b2128d679e6c8", size = 4690196, upload-time = "2026-06-09T22:31:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9f/a1bc8bcc798811b8527eb374bbccf30a3f3e806829d967118222bf1125eb/cryptography-48.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:86be3b1b0b6bf09482fb50a979c508d2950ed95f5621ec77f4e385962006b83a", size = 4696782, upload-time = "2026-06-09T22:31:45.615Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c2/81a4fb4e4373c500bb526bc337ac5719dd31dd15b970b84a238168c6aa08/cryptography-48.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4ab0a343c807bbcd90c971cd1ecf072937cd01847a9e002bef88fb47ac6be577", size = 4696618, upload-time = "2026-06-09T22:31:11.564Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/0b/aa68b221dde92d09cb29a024ede17550ee21e77a404e59fc093c82bb51e1/cryptography-48.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9621de99d2da096006b629979efd8ae7eb2d8b822488d0c89ee4000c306c59b1", size = 5289970, upload-time = "2026-06-09T22:31:20.368Z" },
+    { url = "https://files.pythonhosted.org/packages/78/13/fba657f958d2af66ea959a4ba01212632089249d34af1ae48054136344d7/cryptography-48.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:88c852a0ae366e262e5a1744b685e6a433dc8788dd2a277e418bf4904203609d", size = 4731873, upload-time = "2026-06-09T22:31:22.253Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4c/9a964756d24a26b3e34dfcb16f961b89838786e6700b635b0d1e3adff4b6/cryptography-48.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:43c5835e2cb98c8733d86f57d6fc879b613f5c3478607281c3e36daffc6dd8a6", size = 4330804, upload-time = "2026-06-09T22:31:36.56Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/0f/a10f3a6eb12950a10e3a874070283aa2dd5875b2bfd15fad8a3e17b3f13e/cryptography-48.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:fe0180af5bf9236518a087e35bf2d9a347d5f5f51e63c579d683ddff424e3d46", size = 4696217, upload-time = "2026-06-09T22:31:13.351Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6f/5cd12f951165ea73ef85266775d97e4c763b2474ccfd816dd69d3a18d6f8/cryptography-48.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:b7a2d1a937a738a881737cec135a38bb61470589b17515b9f73f571d0ae10401", size = 5245252, upload-time = "2026-06-09T22:32:02.193Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ab/8aaa12e4516ec4464033ab79b6f3b592bd5a92102467c4ace8a0d970203f/cryptography-48.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b74ca3b8e5ecdd833bf6a002ca41b4793bb27fb8f1c06ffaf2643c9e9140e31b", size = 4731388, upload-time = "2026-06-09T22:32:04.019Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/24/50027ea4dca85ec1f40688f3c24fb32ccacd520583c9592c3cc95628e6fb/cryptography-48.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2c37f2461406063b417837f5f3daab668652acd82423efcd7f0a9f04be972de1", size = 4824186, upload-time = "2026-06-09T22:32:18.707Z" },
+    { url = "https://files.pythonhosted.org/packages/52/41/04cb5eb17085ade6f50cc611fb657df6a0f5885350de8764ece89c050197/cryptography-48.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:86fe77abb1bd87afb251d4d02ada7ecf53a32cee9b67d976abb2e45a13297475", size = 4964539, upload-time = "2026-06-09T22:31:18.793Z" },
+    { url = "https://files.pythonhosted.org/packages/36/bf/ed70785c496e89d7e73b7cda2d21f2447fd6d4e821714b8d04ff217fed92/cryptography-48.0.1-cp39-abi3-win32.whl", hash = "sha256:6b2c0c3e6ccf3ade7750f836ef3ee36eea250cc467d45c256895573ac08cc6f1", size = 3282307, upload-time = "2026-06-09T22:30:53.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ff/371ea7d252656ee1eb6d83eeeef3d1d0c6baf1d6497687d081ea03814670/cryptography-48.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:9a49ca6c81417f6a5edb50375a60cccdd70fa0a91a5211829dbea74eba94d2ac", size = 3793408, upload-time = "2026-06-09T22:32:15.191Z" },
+]
+
+[[package]]
+name = "kinglet"
+version = "1.9.0"
+source = { directory = "/Users/mitchellcurrie/Projects/Kinglet" }
+dependencies = [
+    { name = "cryptography", marker = "sys_platform != 'emscripten'" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.0" },
+    { name = "black", marker = "extra == 'dev'", specifier = ">=22.0" },
+    { name = "coverage", marker = "extra == 'test'", specifier = ">=6.0" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten'", specifier = ">=46.0.7" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and extra == 'crypto'", specifier = ">=46.0.7" },
+    { name = "cryptography", marker = "extra == 'dev'", specifier = ">=46.0.7" },
+    { name = "cryptography", marker = "extra == 'test'", specifier = ">=46.0.7" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
+    { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.21" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "safety", marker = "extra == 'dev'", specifier = ">=2.0.0" },
+]
+provides-extras = ["crypto", "dev", "test"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "diff-cover", specifier = ">=9.6.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "keyring", specifier = ">=25.7.0" },
+    { name = "pre-commit", specifier = ">=4.3.0" },
+    { name = "pytest-asyncio", specifier = ">=0.21" },
+    { name = "pytest-cov", specifier = ">=6.2.1" },
+    { name = "ruff", specifier = ">=0.12.10" },
+]
+
+[[package]]
+name = "kinglet-totp-workers-demo"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "kinglet" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "workers-py" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "kinglet", directory = "/Users/mitchellcurrie/Projects/Kinglet" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "workers-py" }]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjson5"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/9a/3db19560e968d6e85b2a4ddf4b949c6ebf9dd1dcfb5a9f37736f8adeb927/pyjson5-2.0.1.tar.gz", hash = "sha256:a5b0e322e847b198a50d8a1ef16d6b2b19129644dc018d76773e81ef1487ca39", size = 352242, upload-time = "2026-05-15T16:12:54.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/41/be622b742fe4749fefa9d8a923b1cf5e51a1e8e4b4930fa8ea8c531b243d/pyjson5-2.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ee62394660d54e76ff8a968c8194b252be23d184f05a00238d4def9624454ea6", size = 302636, upload-time = "2026-05-15T16:06:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/e2/50378c3bec9164c1bb983ca15ed59f8be498981b790a90d1410a1016ffe2/pyjson5-2.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:58dfa4cf5c327e14c530b16c23e812c021fe53b19e6f9cdfce257d8c02244895", size = 158588, upload-time = "2026-05-15T16:06:09.684Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7d/5de0f82c144b6fc2fa2e3fde5517257733a91d24734b5d2415b7e991e8fd/pyjson5-2.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:07cb90a31f962a6de9e49592a306046ee015da73510c6d215e9481a2a21c9ac2", size = 153741, upload-time = "2026-05-15T16:06:11.114Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/ac/174ca02e5f3ed8245dc48247e534880bbec1528c0c4eaa768fafa9417dda/pyjson5-2.0.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ef4026a90a68cd2bcb64d89ca064a1615b60a61c7694714e2b8ef30434f365b5", size = 185450, upload-time = "2026-05-15T16:06:12.883Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/0d/bfc553176b7e109b72f23697ab1fd1a77d7fd5c6626d6e23936f13d5884e/pyjson5-2.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04b4929a7adf0e0720da92ac54c92d408e8057158be3ccc34da17c7767a9af78", size = 163331, upload-time = "2026-05-15T16:06:14.314Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/05/b0e67106f78c8ea5ffcf6ce0b8421f38a04d5f37ea88ac70123199755bcb/pyjson5-2.0.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e889b039d6bffda9a6b8d822073bbdb4a60166af22f075e7faa0c03c2dfcf17b", size = 166429, upload-time = "2026-05-15T16:06:16.076Z" },
+    { url = "https://files.pythonhosted.org/packages/81/3c/2366f8ecf053434470eafe1f120f2e235d13015fc50d7f06e55e39b550ab/pyjson5-2.0.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a08e99d0a33463728fb016f5eec680504499c4be280dac016de2da70ec55b0db", size = 180499, upload-time = "2026-05-15T16:06:17.544Z" },
+    { url = "https://files.pythonhosted.org/packages/76/65/9a70876d4dd09ce17678024266406b94b8f1edf9db6c2e3bf76cfa653a13/pyjson5-2.0.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:035c094feb6a9d4312183f9f34228d976102eefb971e9e3dd972d8c7900a466a", size = 187469, upload-time = "2026-05-15T16:06:19.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/43/0c0bcbf9a9ef7fdcd49dc0992a3a206244c2c2baa7b409932464cf26f1a5/pyjson5-2.0.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6d178025a5317db44663dc87aab90f34674991b3da40dbedc3c108e7b03b6466", size = 176032, upload-time = "2026-05-15T16:06:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2c/32213674010c44db265d45e977a431cbde971c45342b483f7af337811403/pyjson5-2.0.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:381ca5b3172bccf9c29c5823a0173ab9118d579d0f5bb4fca20b803daa6e72d5", size = 171477, upload-time = "2026-05-15T16:06:23.017Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/49/da5417d592ac75a23d1ca2dfda846391ccf137edd89054b780866c592b65/pyjson5-2.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8e158caf0dd7fbf7afe12f92fcc9cba26bceac4b38615c087fd592e9e3240d9f", size = 1145571, upload-time = "2026-05-15T16:06:24.757Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/1f0c326b3a3267f28b7b9e2ac07121386ec20ee8f9dd49955af4faa17ba7/pyjson5-2.0.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c8010e9a02b6a0719234f8d074639f9051afe579ff0f74d3367af1d8b4c7d839", size = 1010388, upload-time = "2026-05-15T16:06:26.574Z" },
+    { url = "https://files.pythonhosted.org/packages/de/c8/76f2739a8715061755f12f4d2795f6c4079aeadd166c56d0992521442d5b/pyjson5-2.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3543e067d1d8ab6cb1cd41add38a42eaf82e9a7e802e8a08f1acda9f22199b00", size = 1323111, upload-time = "2026-05-15T16:06:28.805Z" },
+    { url = "https://files.pythonhosted.org/packages/50/7a/683e1586fa076fb344aec23a647d67f427847b6bffb1001d56e86aa8da33/pyjson5-2.0.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3e496938e7e0defc33bfbd0ff581d4ffdc428c598cc5d679232f34df27f7330a", size = 1240671, upload-time = "2026-05-15T16:06:30.473Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/8e/6638b0b22344b23cae1271b0211668be54b3f76183bd8d4f89a2edd8e562/pyjson5-2.0.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2badbc101908123905a38789cc552b99ab896a7ec0ce4fa6ee2bb7b613c85c1b", size = 1178013, upload-time = "2026-05-15T16:06:32.212Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/21/d44540d3cdc670e5c6e665471361f557ef8c7d56964cd433524208b3707b/pyjson5-2.0.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:b1b0df4898e2e046fa1e9b5df436fe11d9b681b1e5fc9877508d982d2059aaf1", size = 1354907, upload-time = "2026-05-15T16:06:33.922Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/74/fceedd2709760f5c85e75b508002af9b4c2da8af20a80e62b2d0e2358a15/pyjson5-2.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8fcc96c429888f2293f672e33d01da8a0847cd5116a773c9a1903b8bc2f12bc1", size = 1208847, upload-time = "2026-05-15T16:06:35.883Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3a/d2f062b5801b3034ecb16ffb0801d7b4a1d6abae4cd4615482dbf62f1ed8/pyjson5-2.0.1-cp312-cp312-win32.whl", hash = "sha256:48c97e2f7f02171948f8a7ed6c9b2b2faea00653a3348d9e810238a688f07b6c", size = 115562, upload-time = "2026-05-15T16:09:24.807Z" },
+    { url = "https://files.pythonhosted.org/packages/26/13/2265cf16720defdc87672b68ff5edf83820bd76e59e32f8384c9cb1ae619/pyjson5-2.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:8dea9976eea0aa7af8b5ad49df3fa831d6bda08ffd7bb11409d6a81961491219", size = 136176, upload-time = "2026-05-15T16:09:25.931Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/92/a8947e646ce642555ac22b31f44b7168c81b0e364d0f2711d571955229b6/pyjson5-2.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:264ab65fb7d68a763567c2302151f1f074bf053c8479939aa8e75f5f9518fe31", size = 116752, upload-time = "2026-05-15T16:09:27.274Z" },
+    { url = "https://files.pythonhosted.org/packages/93/2c/0619f89a9576f335ba63eb851e73ba507480a8c7f28a2e7de2501ed3d303/pyjson5-2.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8a661d292801b38434d5288bf7329f9b50b3a693b1d2941c7595175842692eba", size = 301821, upload-time = "2026-05-15T16:09:28.721Z" },
+    { url = "https://files.pythonhosted.org/packages/91/31/7824913ec71e7421d6a57bc06228f3e2d946d8e8f738f898572dded0dc57/pyjson5-2.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cb5c1c066038ce6e1922d9d5be23f5cd14d5b5a3c96e6358aa5d0e379014a93", size = 158201, upload-time = "2026-05-15T16:09:30.261Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/7d/4ddb249563a838425242342d2cf67976ccc292a831b543a92fa1a8a83b11/pyjson5-2.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7417eab751817fa5f070e41975d9df4aec3532d21389073318161f63cd96d636", size = 153244, upload-time = "2026-05-15T16:09:32.04Z" },
+    { url = "https://files.pythonhosted.org/packages/02/39/7622416ac0570d9ce377447bd5b2ec9383c1282e63cc6d0b65779f1336fa/pyjson5-2.0.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cc4802093b4ab9039367774988486fd04754cf416c32aebf94a94bafd8b8a478", size = 185568, upload-time = "2026-05-15T16:09:33.719Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/90/2f317da231477b77481020d79c73bbe10625e4925ceeae77603726ef1763/pyjson5-2.0.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc3181274ed19ecb2315cf85a499bf83002554f42c72453666c616059d665a7b", size = 163169, upload-time = "2026-05-15T16:09:34.865Z" },
+    { url = "https://files.pythonhosted.org/packages/02/b3/20023c3cfe2f2c2523007d7031b5b7ad7ccd8856d2665547683cebaa6f8e/pyjson5-2.0.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5398306b8aa253e620af9ed8085767de9cd28d6846da45e535e80fcffa9f33d7", size = 166514, upload-time = "2026-05-15T16:09:36.383Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/1c/b863e502153477b2845a54b688b72436457aca5107b300fca95e98184551/pyjson5-2.0.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b97b592287d52a6ec5af84dca94aab02b185f72f8ddb6fc99c58efb8891be5cd", size = 179907, upload-time = "2026-05-15T16:09:38.166Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b2/413fcb76632e5f6fa89a2ec83976755b5bb4696c6d9eca9ff3c70cd717b6/pyjson5-2.0.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4efbf5e910a3aa6f330a92d1ae940dda5ed662976ed5056526baaf2e1821f95d", size = 187171, upload-time = "2026-05-15T16:09:39.624Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/11/66151b819407ab589aef36582038257f1ef42dc065e3423b3d8274f4fcd2/pyjson5-2.0.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e042f9b869e7f21d5f53a2638e5d0cf1daaba2342127c8777c502daf972602e", size = 175564, upload-time = "2026-05-15T16:09:41.356Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/98/deb70690dab994474ea527cba91f43ae55928bcff498c441e812b60fc1e2/pyjson5-2.0.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:26074370d7a6dd38b6e8c28a2f10c790fc6dec938ec22ec3de6c93c97d195f10", size = 171530, upload-time = "2026-05-15T16:09:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/be/969752a3a052d00698b6e1dd926c627d7a6475a7c8dd390db148363544f8/pyjson5-2.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3cb163a495096716a7a01d052b60bda0308ecfaeddcb2d50a247ba9d707e3e40", size = 1145510, upload-time = "2026-05-15T16:09:45.005Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/be/4c5c92cdda5a911ee4450a74281782335e7ce6715638308322beb96be639/pyjson5-2.0.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5fdd66bdddc2d53421ab7427bedcd2ca9b2f1b4b3b464381aa60d305c94be38c", size = 1010114, upload-time = "2026-05-15T16:09:47.081Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1e/72283bc505d77dcdab7eaeb0020cf0fd79a05d2991e886d1fcfa73e88ae1/pyjson5-2.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4ad222a3eff1cc93f9b70894c5f3d2ff5e46531e88feaa4818e329d5f3ae4307", size = 1322915, upload-time = "2026-05-15T16:09:48.885Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b4/94a09e744a6bb6e76108b61a28a7cc5ecab1b8105cacde7548359b3b74a3/pyjson5-2.0.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:63f5cf25113dd1bf3bfeda211d99413e58ec6b9036ff34f7b69f85f23695e9c4", size = 1240126, upload-time = "2026-05-15T16:09:50.638Z" },
+    { url = "https://files.pythonhosted.org/packages/af/29/4549380cae425ee112f3c154606c35f5211c12ddf415f079c2b23f2d493b/pyjson5-2.0.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b0001eecce9080e6c170e978786501e8931e2075a3d15f5260e1bdd6a45e8976", size = 1178022, upload-time = "2026-05-15T16:09:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1a/5a8a869e855645858e45dbd077204cec3a85b2f2e669bc3c8cefe9c4a70e/pyjson5-2.0.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:40371c73cc83ed81914028786a6cc5950bdf300ae82443df83a5dfa80c582fca", size = 1355161, upload-time = "2026-05-15T16:09:55.177Z" },
+    { url = "https://files.pythonhosted.org/packages/82/32/827066cd946447648275a892f494f4572d78e6a79d877fa6b6c14af599d8/pyjson5-2.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c9dca542eeb6e8fbbc1fe3373bfd18ae6250f1aedc78f39242ac12c8837091b8", size = 1208864, upload-time = "2026-05-15T16:09:56.919Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cc/a9bc12aff47d8bfd3074a21e3fb056ec0028fac28f8ec7e0fe4449d050f5/pyjson5-2.0.1-cp313-cp313-win32.whl", hash = "sha256:d30c8b2c91d530be475a8fab6dde8c3bcd3e89b999c9e0f05aec2bf2c24b0638", size = 115461, upload-time = "2026-05-15T16:10:30.711Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c7/fa3fc956fbc3fa6250c8b99ef75a8f52b691780fca1bfb368340283bd898/pyjson5-2.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:67f8f5b8d3e3b2ca5f618c928729986aa00fb588c476c0d0d3a151633ff41e0d", size = 135836, upload-time = "2026-05-15T16:10:32.062Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/e457b20d1e36a766d3ccd09c418b7ef41acabb679ff2248bb1cd38247ce6/pyjson5-2.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:bdf30ce5b1242f63254d936b30af75cae237fab0ee71cc2544163c82b6bc9201", size = 116652, upload-time = "2026-05-15T16:10:33.39Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/4c/6266789e615576b62d2db6de26a3b4b8f4cc7a8ff23fe24e48363bca1682/pyjson5-2.0.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:954c14d40022fa40e0d36e0ebd337e9e90fd71145592d25a0e2868344e3daca0", size = 320487, upload-time = "2026-05-15T16:09:58.38Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/75/c4a563034805e20b274fe4db963e1d480001931d88fe70b7d082033b7dcb/pyjson5-2.0.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:f57529b98d21e8b76f8bc51af9d3c3057dd04a92287fd21ef7ec55255ca6f5c5", size = 166879, upload-time = "2026-05-15T16:09:59.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/5e6ec3580379794e9a99a402465f74586e93e93814974172202d1254fa89/pyjson5-2.0.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:545b655ef0b59f39fc29e2b63b4dadd45e447ad77bad2fdca859ff4db69e21f5", size = 162235, upload-time = "2026-05-15T16:10:01.147Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/48/b2d0e868ef8375eb0696ddc74f71028fc4fcd26cdddaeb34485214f2dc87/pyjson5-2.0.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b519de49dd4cbf254179749e5c6bfe9bd8fd1f97e7755bff2e17cc6f79f85aa5", size = 182162, upload-time = "2026-05-15T16:10:02.523Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/18/fed02a3d68c3badb87394e8420b72d7cb165ade208c1e02561637409aa99/pyjson5-2.0.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de48fbd0466c114c17f408be7bcbc5b3aedeb29ff5f73187022915e6d5eb7817", size = 169487, upload-time = "2026-05-15T16:10:03.876Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/90/dc897332dda24e949828616e8e74d7937b587a56789f3aca148fcadddde2/pyjson5-2.0.1-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fe6516ff9ab94368c18ff8ac0ebdb53fac9e047da093d43e67d5e7cd98cdd0bf", size = 164128, upload-time = "2026-05-15T16:10:05.588Z" },
+    { url = "https://files.pythonhosted.org/packages/39/09/90104baeab58adfe63bda804174ef1806b1cabb1692e047fabc2f4aa1799/pyjson5-2.0.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ea7aadacac7ac6661117b708175f6beff75e132322c08bbf3794d8ec4ba572b4", size = 184306, upload-time = "2026-05-15T16:10:06.986Z" },
+    { url = "https://files.pythonhosted.org/packages/89/73/613efc3cdab5cf9ec399e6c5a0463b672e5f5cbd693a3a4d82cbdda19476/pyjson5-2.0.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e5c339bcac113dfc30a1f88f23af273d67bb6169abee1684c0dd27daa71a32f9", size = 192239, upload-time = "2026-05-15T16:10:08.727Z" },
+    { url = "https://files.pythonhosted.org/packages/47/2a/17b97e02b37ab9353fc9713e56470be3d2539501ed18d6c676cfbcd0a57c/pyjson5-2.0.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:075de0f1e5e0ffee174a8941b5d9d8af632772a6e5eebe92fb0899db7f6ab7fa", size = 177652, upload-time = "2026-05-15T16:10:10.19Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/43/a05331ba88fd1aa09ca418548c6b06692e34b2a64b109bb363e01ecafdeb/pyjson5-2.0.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c463c9bf508c1d316191898a3c0bfc03dd3de67bdc02f480b0742ac5c859eaeb", size = 174860, upload-time = "2026-05-15T16:10:11.976Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/00/5d253751f4d27b7e63fdfd765041593fa588395f45b9cea496878d964448/pyjson5-2.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:54427c8cad0c1a516bad5b4457167cde1e7ef7ee563e28a944f59b3c7413b6a0", size = 1151556, upload-time = "2026-05-15T16:10:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f7/a30eed477295e92dfd59553063cf82bf510a7052efc7720c9c50d0082fdb/pyjson5-2.0.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:ca04839cecd364cb53de7ebcd81fd5915193707d968730ea1c8d4ff5c9c2f1a8", size = 1012330, upload-time = "2026-05-15T16:10:15.171Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/60/80818fad90a99336f8bfc686d76d0b2d7c8bb51e8de5d031620fa1a2d7a1/pyjson5-2.0.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:13a2de8b14aeb576b1623c8af419510bf871b8d9cc2308db41a46bcc94d00f2f", size = 1320970, upload-time = "2026-05-15T16:10:16.863Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3f/090eb3e0971d067defb58bbfd738f74a09be495c6f4f00d5d76a10755bca/pyjson5-2.0.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c8a689f5252e9791bfbc8fa916999202556a1e8c7b24dfd72de1ad84c493e10a", size = 1244775, upload-time = "2026-05-15T16:10:19.416Z" },
+    { url = "https://files.pythonhosted.org/packages/61/38/e7546ad733affe51a5462bad21bceb4fd659baf24930bd141627ce56279b/pyjson5-2.0.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:3dc0c2c80fd9d1e4c26f8b6c91a54d38b48648b93ae3f09355856c75fda3e460", size = 1182149, upload-time = "2026-05-15T16:10:21.696Z" },
+    { url = "https://files.pythonhosted.org/packages/90/2c/016647580d8a82ee53b4cb9ddb96deb4b157ccea9624bba61de4aa2cd25c/pyjson5-2.0.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:13d78b3e2c60b81bd7e6b00e6ab24a664ba1fd64b5d86baa65c4cdfae1fff7ae", size = 1358579, upload-time = "2026-05-15T16:10:23.649Z" },
+    { url = "https://files.pythonhosted.org/packages/01/45/8b84ff7a0c4d8c12a76e097c67af62abe986a18d1ab2540764dd6eaa0253/pyjson5-2.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a7b640dbeabbd7d975170f793f90a7500cc5d510aeae9364a1bc558bcc5336ed", size = 1211015, upload-time = "2026-05-15T16:10:25.4Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/48/d8f34de7a7319f5966bdfd10f133e689ba01f138d2040bf792f1ca8b18e1/pyjson5-2.0.1-cp313-cp313t-win32.whl", hash = "sha256:46e7c5525034fde8abf3aaf100ed7660c1b618ccd3205544ed7c99e4c55cf201", size = 131660, upload-time = "2026-05-15T16:10:26.747Z" },
+    { url = "https://files.pythonhosted.org/packages/06/aa/0bd437252134115a846ffc061078c85f8e8c325c86abcaa862c134d3c57e/pyjson5-2.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:207c00e7f9641e0358bdc848a1c0610f26f2e8bd51d73bd64e5a0ab3b725f1d8", size = 157717, upload-time = "2026-05-15T16:10:28.053Z" },
+    { url = "https://files.pythonhosted.org/packages/24/61/7849b04a0dc78f73905189400ac99c45de8eec2ec451ce9c6990fb3588e5/pyjson5-2.0.1-cp313-cp313t-win_arm64.whl", hash = "sha256:4917d5b6186bfa48ec4d85326e2a09769a5f7844963307ab2710429e1f743264", size = 126281, upload-time = "2026-05-15T16:10:29.378Z" },
+    { url = "https://files.pythonhosted.org/packages/89/41/70aa1cb1fb0a3ac4c9b8cd405c0c85ba935c53fdfae6271b8eae364b92d1/pyjson5-2.0.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:573fecd7cad4e24d232053f9ebf331c80fe1b0ed6e2064f7614797a7f691e7ca", size = 303706, upload-time = "2026-05-15T16:10:35.163Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d9/caf44bf3d33b9502dc4b8ed5d0c7a8af8fbe33001e82414c0407f39f18bd/pyjson5-2.0.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a8ade508a046a5407a322c098e3b7e6033216b158a7746eb8962b7a4cdbf9248", size = 158915, upload-time = "2026-05-15T16:10:36.496Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/94/f2bab1ce2eac8f77e16dcd0a1ba39de20733a84b9961c3504af0dd68bceb/pyjson5-2.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4635e349bb1d1f1e854dc790f14be31b6cb198d6453848e8d86818104074f805", size = 154199, upload-time = "2026-05-15T16:10:37.902Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c4/d94573ca37486af3d6a72f2582844d7d490d8e55639e0cfba371ce91442f/pyjson5-2.0.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3d274697f81f143abac12ce256a06b61635c30d0f8cc11eefae7182655dac9a5", size = 186060, upload-time = "2026-05-15T16:10:39.603Z" },
+    { url = "https://files.pythonhosted.org/packages/03/cc/c42e697def319b286fdcb912939c044cc94bd1cfc7338b6dbb566f817f29/pyjson5-2.0.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be4e2242e55a2651fd8696cfd67ec8e04f54f4ed6c089cceea2b63763a7516d8", size = 165796, upload-time = "2026-05-15T16:10:40.967Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/dd/f22a5f0e619ef22b8e32520a91bd92f815d50f9ec2d67cfe5974eab9476c/pyjson5-2.0.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:af855c680feaa39cae4a44914ee2863eeae1549f37ce58069c747b3d4803999a", size = 165262, upload-time = "2026-05-15T16:10:42.391Z" },
+    { url = "https://files.pythonhosted.org/packages/99/8b/90e22ecb12d51ccdc68325b6b051002e6103cc4600a335d9ed13828acdd9/pyjson5-2.0.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bb769d90516da904e6cf0ba58f3d5830f4a5804486b5e85c5ca42ba3146d187a", size = 181608, upload-time = "2026-05-15T16:10:43.914Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ab/237f9036eed73e08cf8861466d3d1182ef1c88506bd29955740dcadb24ff/pyjson5-2.0.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6484c14e07aa46abeb3cb2ff0204a765260763ad7cf3f87f601f26b20ed607f3", size = 189582, upload-time = "2026-05-15T16:10:45.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3d/3df8d5f003910a9291e5f04fa178f626e3c8553a5986dc62589ca74195ff/pyjson5-2.0.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc03673adb544324500d79b2acfe2ced038998b2aceb564d335de9cc238cbdb0", size = 176321, upload-time = "2026-05-15T16:10:47.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d9/a458a54f780bafec1b44ee3c27cb3007a83fb7bd4f1c17ac6bf519fd6151/pyjson5-2.0.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d714daf784bec2e14fc06c0c26e4a373a6157eaeddaed2d5a7b7b6ae2aabc33", size = 171956, upload-time = "2026-05-15T16:10:49.174Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d8/1010e0147c8862dc0881cf3656364d3d87a5e336d290fe4cb0b92223e14c/pyjson5-2.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5cf3ded356730e08b5941a16db6525efc0de26f35468ab09ad573056c4efc6e5", size = 1147679, upload-time = "2026-05-15T16:10:51.005Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2f/91c8d8cdb4a2e4bbe8f14b9b57d717988e14830f2ed4a4f08d503cb5edde/pyjson5-2.0.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:cc00d4669fb4170c28b2c9ed3cd1c2af9f21727c55d6866030cc154f31f68747", size = 1008216, upload-time = "2026-05-15T16:10:53.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d7/25c3f8693660a35be7bb4eb71b0d10d9a6981e986723a4881d607f0c6462/pyjson5-2.0.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a77a91c2e019476345c03cde105da44100daaabc3fa56f82f2bd9eb2ebbcb698", size = 1323856, upload-time = "2026-05-15T16:10:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/25/82f0f83556ff68ec0ca1129ba9afeb14149cd421dc74823cdf10c209c95c/pyjson5-2.0.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9ae54e5d717982cb7a082c700ab1f7f965c6aedea6fcb003ec4bdeac4f02bf52", size = 1241860, upload-time = "2026-05-15T16:10:57.635Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/01/2c4695fc06a0f3f29041a875d3bb24f904c9ae7b3d8dbfa1f8db17ce995c/pyjson5-2.0.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:ce4f5b67b3a6fab623a31d83416b51a5b2c97cb172194f214078484bbb4783a6", size = 1178443, upload-time = "2026-05-15T16:10:59.398Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ae/c10f534037b096aca21b90017ac9d41f791572dc3ec31fcd92db8ddcd256/pyjson5-2.0.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f8d2e61f7bed0b40cfe5f62375581bf56d7b5b9707c9d74747b5931149d7d376", size = 1357739, upload-time = "2026-05-15T16:11:01.189Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f0/655224f78ede087aa6a295c4745423e0104dd31f67928675b1a4cea72a0a/pyjson5-2.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2930140edd1a64eb42689993c5ae317bca2e6bc785b5dc5053bd5e9d184c98ad", size = 1209542, upload-time = "2026-05-15T16:11:03.364Z" },
+    { url = "https://files.pythonhosted.org/packages/73/52/a7b2a26625136fcd0f92e17beaaae51e04923cc2e28502db354d4de061b4/pyjson5-2.0.1-cp314-cp314-win32.whl", hash = "sha256:51733f91dda897239ca10928f363ce6f4b5eadaf797e74477f6c1c3222c185a7", size = 118342, upload-time = "2026-05-15T16:11:40.009Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8e/79db426fff3a41610076989d4060cc18a6508ebd3c7877155f6709eea102/pyjson5-2.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:698c73aacff49ea35bbbf7f700a97785626201ea7aa2e1f1e0a4fe23788c3be2", size = 138408, upload-time = "2026-05-15T16:11:41.757Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/1b/385da14c05412bca15e86551dde91959686c8bddf7e78722bdc627fa6815/pyjson5-2.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:d447e2e5756f89abfd0ad82d1438075bcbc701c1cc9279b43d24825aaac67356", size = 120905, upload-time = "2026-05-15T16:11:43.146Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/04/cd69739556d304d3ea48064ea7d47e5ff7321b0032d7ad78864bceaa0cae/pyjson5-2.0.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5603be4f0cb9685d7c2cbd408ddec21b33f415252bee00ac7969f20b5789a1d1", size = 321150, upload-time = "2026-05-15T16:11:05.07Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d4/6d98268ed07a2cac1e79634fcd3dc280d2503ade5f3c465f7aa095951444/pyjson5-2.0.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:87267520a256b3f2dba7f2995b745e8b3f2dd72bbf8436010a5191f7809f8ab6", size = 167540, upload-time = "2026-05-15T16:11:06.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c6/8855a9462bdbc8306cba62793e23cc2952dfcbcbcab8e0413f570c891361/pyjson5-2.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:77e58307b74019d90aff9f2781bcffbbea3315b15fc814f8fa9b8d334b956ff4", size = 162533, upload-time = "2026-05-15T16:11:08.218Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/a3/1092f68538ee71ed8027393ab5e71aa9c4a114e493e30a55e46e34c2ffb9/pyjson5-2.0.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:dd1712038837342dea73ed526883e53c6e85a158242b6f574b9ad9cdd3199c7f", size = 184165, upload-time = "2026-05-15T16:11:09.639Z" },
+    { url = "https://files.pythonhosted.org/packages/46/63/bb9f42a4047284ea59064c134c88dfac3b7f5273e40fe548d6a086cea452/pyjson5-2.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1dba36677c77aed5d680827c65478933705ca156a34838f1250ea191ffc27662", size = 170075, upload-time = "2026-05-15T16:11:11.105Z" },
+    { url = "https://files.pythonhosted.org/packages/55/2a/0379aa5184e986d0f9af2919712c148d81928ce7d2d7950407e271b1df3b/pyjson5-2.0.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:04356d0c09e58907f60675d33859f269473479b90add5026231ef2fadba5207e", size = 164100, upload-time = "2026-05-15T16:11:12.909Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d5/2087af69695c28c7fe796afc73dec7f0b0b9bc123ec329e45928d58d4705/pyjson5-2.0.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b331a0fbe2ae26f4ccb88045ebaecc00aeeeab23ff858f9a2223cedd969ec6d6", size = 184674, upload-time = "2026-05-15T16:11:14.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/06/cf1b2744e07f1689cb0ac663e162a060b81cd358474754fe9f3bf02d5398/pyjson5-2.0.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ca55878d923ba5764254ad1c020c22b33e6161b3555d1f457b8060f2b3c6c17", size = 193047, upload-time = "2026-05-15T16:11:15.969Z" },
+    { url = "https://files.pythonhosted.org/packages/54/e6/a6b0deb6a3f393907c6d9115a7ac8e27557109204b56b05d3b57c51fc2ca/pyjson5-2.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:35e18d11e4c2034b78a664affe18c153a8efbf8872cf6bed7f12dc4fb819d440", size = 178712, upload-time = "2026-05-15T16:11:17.364Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/48/9e5c16daba56dfdb481baab85d1197e14ae3f403902fc23cdca14d14351b/pyjson5-2.0.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b710a7489b6e134890eaa1fdb285e9644a1e730c1cfcf1cd90a87859b87a84a9", size = 175642, upload-time = "2026-05-15T16:11:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/32/f07d4dbd8cf733f9e3f3e9c9abedfbc23da1e5cfa7fed46aebae07ca6f25/pyjson5-2.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:08920c0dd6aba3fb6bc6c849e6f05731c5fb2716cd651de424ff60cdd12eae65", size = 1152219, upload-time = "2026-05-15T16:11:20.54Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9d/0ddbb89d381bc27f3740850d5d664c1f6f76620ad879ff5eb2506a4dfd6c/pyjson5-2.0.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:e166dadb3275025cff5ee8602131372a3ea171c6727b3fc6e44697348e3972c5", size = 1013305, upload-time = "2026-05-15T16:11:22.702Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/93/0f44886391dd2249ad9cf98c2deb3f26d1a115dd5a215629af7455765968/pyjson5-2.0.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ea3c2b4e7b8e209e7f59bd6a925d79b69cd0a4ffa12f2df0c6af55514c8b2227", size = 1322840, upload-time = "2026-05-15T16:11:24.918Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/29/c478dc24dfcfc07e407ff8669df265ecc51fed5e7d47e51a01f17fd1c53f/pyjson5-2.0.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b710fc8ce00c984c8865131f05a8536163e1d3caffb9d081647879eca7424670", size = 1245221, upload-time = "2026-05-15T16:11:26.873Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/f0/5fef8c47c5b7052da79af6425a021040402a9a09b37c5687d91f98696a27/pyjson5-2.0.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9784d79275d1b06d95f2920c3f260ce5d3f6671f65a1fae1464f83fbfc834a0", size = 1182991, upload-time = "2026-05-15T16:11:29.258Z" },
+    { url = "https://files.pythonhosted.org/packages/90/33/4d3a9d3159cdff1f1886d39f1991e6c8d5927f9b606cfc9743b5bef98c2a/pyjson5-2.0.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0ef86c53d0e14991b5b0fe58f225e3d8faec437aa0a70da4762525b6bc2fca10", size = 1359104, upload-time = "2026-05-15T16:11:31.651Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/04/20eb16c52453aea0af68a697f4058378c9ff871bd2f0bea28eb76ffe12f8/pyjson5-2.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1d9faccf5a9e86f14104eec31c13428ef8baeb867182ce107e0c68fcc5c62477", size = 1212847, upload-time = "2026-05-15T16:11:33.767Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/a3/69bbe93275eafb7802a5b29230cc5c28f9b924c68d15b3ab2d43cfe19825/pyjson5-2.0.1-cp314-cp314t-win32.whl", hash = "sha256:2df497af7ab03cf82d9278a4707a83d0ae4e6d727f919a883b5ccec3f7d92650", size = 139137, upload-time = "2026-05-15T16:11:35.487Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/b865ca6e0ae6887bc2b6b17cd123470ae43ac0fa04a2362d77d4b9f5bd43/pyjson5-2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:3b31cf4f4a4f01800812865af3b02f6700cefb9377e4d9a9c6b78fdcf41fd973", size = 169412, upload-time = "2026-05-15T16:11:36.887Z" },
+    { url = "https://files.pythonhosted.org/packages/68/55/02c734459fef0a955ab3e7e745df415d5f9fc873a4c288765f60f22fbc13/pyjson5-2.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:15f0d8baea89d35c6c01c60b944c778a79cac10f77f71b727f1b244e2c7a8ccb", size = 129061, upload-time = "2026-05-15T16:11:38.712Z" },
+]
+
+[[package]]
+name = "pyodide-cli"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/44/fe74049e3e776bd56fae8bd9370900d6d6dc5e541299ae90cb2330a9a8a4/pyodide_cli-0.5.0.tar.gz", hash = "sha256:14df0797e791558b6976d4612f9df9619334f8914bfe3efbdd22e3886f5275b7", size = 12630, upload-time = "2026-01-28T03:29:06.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/07/76977bbd73c686df55fbc3685c6c336158dc11b2ba155abe3e3a802447b2/pyodide_cli-0.5.0-py3-none-any.whl", hash = "sha256:24c02736f1d6c99396f5e9330fd30bd98db88cf49ef059b62b025fa1f5f6e29c", size = 12684, upload-time = "2026-01-28T03:29:05.527Z" },
+]
+
+[[package]]
+name = "pyodide-py"
+version = "0.27.7"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.13'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/99/d7b3c9137de5a76a63f2ef89d43c878dcb4dce8118866fb58d26290698f9/pyodide_py-0.27.7.tar.gz", hash = "sha256:afb68f8abf503f691a4ab5d2ffdbf6dd05117920508e1161e04a34737c649d36", size = 52051, upload-time = "2025-06-05T04:10:49.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/c5/825f73fb815a17838bef3342999247bea1100a0b2e576e5c17b2bdd68766/pyodide_py-0.27.7-py3-none-any.whl", hash = "sha256:2fa7db63a14720e548eb6174d492643424f8b5f21d43b7c9fecb6d712187fe6a", size = 57930, upload-time = "2025-06-05T04:10:48.789Z" },
+]
+
+[[package]]
+name = "pyodide-py"
+version = "0.29.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/85/db25e6a10a2600cb96e4ebe423ada255aa738b991fd8843776ebe4f3173f/pyodide_py-0.29.4.tar.gz", hash = "sha256:2ef83817457364fd1a3dc42bfd0617350244776c8b9f7e37f17efcbc38e3bf0a", size = 58868, upload-time = "2026-05-07T15:14:45.97Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/03/7805e80a7d9824b03fe40b1c7c4192250f1ea231ee49a57ada62f736c506/pyodide_py-0.29.4-py3-none-any.whl", hash = "sha256:5df0615640e39d3b365da8b8fd653ec0af5361aef28275ded2218af773d766d1", size = 66013, upload-time = "2026-05-07T15:14:44.637Z" },
+]
+
+[[package]]
+name = "pyodide-py"
+version = "314.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/3d/c8ec7c5dc9b2a2815ba5a875f0f38d9cc6b495e25ff3e9a56eb31d8c8466/pyodide_py-314.0.0.tar.gz", hash = "sha256:4aed346c7df4a863539fd97a27bc5c08730f1c93acdb9dd42b7bc218cad9c1e3", size = 62094, upload-time = "2026-06-09T09:47:25.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/df/8fd85a43b01f1461f163854602021bcdbd69ceac0bd8b4a0762822ffbf4c/pyodide_py-314.0.0-py3-none-any.whl", hash = "sha256:556b391409685a831da0d1e19e4dfa89a247adcf5b4331af119711436efc27a8", size = 69690, upload-time = "2026-06-09T09:47:23.962Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "workers-py"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "pyjson5" },
+    { name = "pyodide-cli" },
+    { name = "pyodide-py", version = "0.27.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pyodide-py", version = "0.29.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
+    { name = "pyodide-py", version = "314.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "rich" },
+    { name = "workers-runtime-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/97/e8b69b27149da93ce4c4a6e1a608eb028b81f64ad3acf9cb33fecba02f64/workers_py-1.11.0.tar.gz", hash = "sha256:fe04209f20f41c0c90dbadac6d7b81387a026d63d3c1e5b59eb8ffb7a2b3322f", size = 82741, upload-time = "2026-06-03T16:21:48.029Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/2c/a07c3e45225938cd9483d8dde38ae48c3480d385050a0241f6326a45a796/workers_py-1.11.0-py3-none-any.whl", hash = "sha256:ba0902ce671b1777de64bd695a2e166e0419df1912fbc8ae24121c0a984af000", size = 13742, upload-time = "2026-06-03T16:21:46.408Z" },
+]
+
+[[package]]
+name = "workers-runtime-sdk"
+version = "1.1.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/b7/1c76cc492f39051eb4a062d62b4a3cd6b7ebaaa7200ac67c0c75eead66a7/workers_runtime_sdk-1.1.6.tar.gz", hash = "sha256:4c08ff2d3bd02d3e1ccfbe67d01465a98e8cd88580a39409e653ec5aeac8e793", size = 32956, upload-time = "2026-05-28T04:30:40.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/84/ffef7c26b9fafa108b385de2c789353dcfef0f4684a93754a11968d902ba/workers_runtime_sdk-1.1.6-py3-none-any.whl", hash = "sha256:ba06e3279265395be878711d66bd886667b7b241ed9c97774fa81cd943c4ee6d", size = 20367, upload-time = "2026-05-28T04:30:39.139Z" },
+]

--- a/examples/totp_workers_demo/worker.py
+++ b/examples/totp_workers_demo/worker.py
@@ -60,13 +60,14 @@ async def test_info(request):
 @require_auth
 async def setup_totp(request):
     user = request.state.user
+    claims = user.get("claims", {})
     secret = generate_totp_secret()
     return {
         "user_id": user["id"],
         "secret": secret,
         "qr_url": generate_totp_qr_url(
             secret,
-            user["claims"].get("email", f"user-{user['id']}"),
+            claims.get("email", f"user-{user['id']}"),
             "KingletWorkersDemo",
         ),
     }
@@ -119,8 +120,9 @@ async def roundtrip_secret(request):
 @app.get("/auth/totp/elevated-check")
 @require_elevated_session
 async def elevated_check(request):
+    claims = request.state.user.get("claims", {})
     elevated_token = create_elevated_jwt(
-        {"sub": request.state.user["id"], "email": request.state.user["claims"].get("email", "")},
+        {"sub": request.state.user["id"], "email": claims.get("email", "")},
         _env_get(request.env, "JWT_SECRET"),
     )
     return {

--- a/examples/totp_workers_demo/worker.py
+++ b/examples/totp_workers_demo/worker.py
@@ -1,0 +1,130 @@
+"""
+Kinglet TOTP Workers Demo
+
+This demo exercises the auth and TOTP surface against a real Workers runtime.
+"""
+
+import traceback
+
+from kinglet import Kinglet, Response
+from kinglet.authz import configure_otp_provider, require_auth, require_elevated_session
+from kinglet.totp import (
+    create_elevated_jwt,
+    decrypt_totp_secret,
+    encrypt_totp_secret,
+    generate_totp_qr_url,
+    generate_totp_secret,
+    verify_totp_code,
+)
+
+try:
+    from workers import WorkerEntrypoint
+except ModuleNotFoundError:
+    class WorkerEntrypoint:
+        def __init__(self, ctx=None, env=None):
+            self.ctx = ctx
+            self.env = env
+
+
+app = Kinglet(debug=False)
+
+
+def _env_get(env, key: str, default=None):
+    if isinstance(env, dict):
+        return env.get(key, default)
+    return getattr(env, key, default)
+
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        configure_otp_provider(self.env)
+        return await app(request, self.env)
+
+
+@app.get("/")
+async def health(request):
+    return {"status": "healthy", "demo": "kinglet-totp-workers-demo"}
+
+
+@app.get("/auth/totp/test-info")
+async def test_info(request):
+    return {
+        "environment": _env_get(request.env, "ENVIRONMENT", "unknown"),
+        "totp_enabled": str(_env_get(request.env, "TOTP_ENABLED", "true")).lower()
+        == "true",
+        "has_jwt_secret": bool(_env_get(request.env, "JWT_SECRET", None)),
+    }
+
+
+@app.post("/auth/totp/setup")
+@require_auth
+async def setup_totp(request):
+    user = request.state.user
+    secret = generate_totp_secret()
+    return {
+        "user_id": user["id"],
+        "secret": secret,
+        "qr_url": generate_totp_qr_url(
+            secret,
+            user["claims"].get("email", f"user-{user['id']}"),
+            "KingletWorkersDemo",
+        ),
+    }
+
+
+@app.post("/auth/totp/verify")
+@require_auth
+async def verify_totp(request):
+    body = await request.json() or {}
+    secret = body.get("secret", "")
+    code = body.get("code", "")
+
+    if not secret or not code:
+        return Response({"error": "Code and secret required"}, status=400)
+
+    return {
+        "valid": verify_totp_code(secret, code),
+        "user_id": request.state.user["id"],
+    }
+
+
+@app.post("/auth/totp/roundtrip")
+@require_auth
+async def roundtrip_secret(request):
+    body = await request.json() or {}
+    secret = body.get("secret") or generate_totp_secret()
+    try:
+        encrypted = encrypt_totp_secret(secret, request.env)
+        decrypted = decrypt_totp_secret(encrypted, request.env)
+    except Exception as exc:
+        if str(_env_get(request.env, "MODE", "")).strip().lower() != "prod":
+            return Response(
+                {
+                    "error": "roundtrip failed",
+                    "detail": f"{type(exc).__name__}: {exc}",
+                    "traceback": traceback.format_exc(),
+                },
+                status=500,
+            )
+        raise
+
+    return {
+        "secret": secret,
+        "encrypted": encrypted,
+        "decrypted": decrypted,
+        "ok": secret == decrypted,
+    }
+
+
+@app.get("/auth/totp/elevated-check")
+@require_elevated_session
+async def elevated_check(request):
+    elevated_token = create_elevated_jwt(
+        {"sub": request.state.user["id"], "email": request.state.user["claims"].get("email", "")},
+        _env_get(request.env, "JWT_SECRET"),
+    )
+    return {
+        "ok": True,
+        "user_id": request.state.user["id"],
+        "elevated_token_preview": elevated_token[:24],
+    }

--- a/examples/totp_workers_demo/wrangler.toml
+++ b/examples/totp_workers_demo/wrangler.toml
@@ -1,0 +1,12 @@
+name = "kinglet-totp-workers-demo"
+main = "worker.py"
+compatibility_flags = ["python_workers"]
+compatibility_date = "2026-06-12"
+account_id = "33623e6d0b4793842a1832c5512aeb49"
+
+[vars]
+ENVIRONMENT = "demo"
+MODE = "dev"
+JWT_SECRET = "totp-workers-demo-jwt-secret"
+TOTP_ENABLED = "true"
+TOTP_ENCRYPTION_KEY = "totp-workers-demo-encryption-key-32-chars"

--- a/kinglet/__init__.py
+++ b/kinglet/__init__.py
@@ -2,9 +2,12 @@
 Kinglet - A lightweight routing framework for Python Workers
 """
 
+from importlib import import_module
+
 # Core framework
-# Import specialized modules for FGA support, TOTP, and SES
-from . import authz, ses, totp
+# Import specialized modules for FGA support and SES.
+# TOTP is loaded lazily so auth-only apps do not pay the crypto import cost.
+from . import authz, ses
 from .core import Kinglet, Route, Router
 
 # Decorators
@@ -176,8 +179,17 @@ try:
 except ImportError:
     _openapi_available = False
 
-__version__ = "1.8.2"
+__version__ = "1.9.0"
 __author__ = "Mitchell Currie"
+
+
+def __getattr__(name: str):
+    if name == "totp":
+        module = import_module(".totp", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # Export commonly used items
 __all__ = [

--- a/kinglet/authz.py
+++ b/kinglet/authz.py
@@ -11,7 +11,6 @@ from typing import Any
 
 from .constants import AUTH_REQUIRED, NOT_FOUND, TOTP_STEP_UP_PATH
 from .http import Response  # Import directly from http module
-from .totp import DummyOTPProvider, set_otp_provider  # TOTP support
 
 
 def _env_get(env_source, key: str, default=None):
@@ -401,5 +400,7 @@ def configure_otp_provider(env) -> None:
     totp_enabled = _env_flag(env, "TOTP_ENABLED", True)
     if not totp_enabled:
         # Use dummy provider for development/testing
+        from .totp import DummyOTPProvider, set_otp_provider
+
         set_otp_provider(DummyOTPProvider())
     # Production provider is the default

--- a/kinglet/totp.py
+++ b/kinglet/totp.py
@@ -30,7 +30,20 @@ def _import_cryptography_aead():
     return aead_mod.AESGCM, exc_mod.InvalidTag
 
 
-AESGCM, InvalidTag = _import_cryptography_aead()
+def _cryptography_aead_available() -> bool:
+    """Load and cache the cryptography AES-GCM backend if present."""
+    global AESGCM, InvalidTag
+
+    if AESGCM is False and InvalidTag is False:
+        return False
+    if AESGCM is not None and InvalidTag is not None:
+        return True
+
+    AESGCM, InvalidTag = _import_cryptography_aead()
+    if AESGCM is None or InvalidTag is None:
+        AESGCM = InvalidTag = False
+        return False
+    return True
 
 # Test TOTP secret that generates predictable codes for development/testing
 # This secret will generate "000000" at Unix timestamp 0 (and cyclically)
@@ -52,12 +65,17 @@ def _env_get(env_source: Any, key: str, default=None):
     return getattr(env_source, key, default)
 
 
+def _is_pyodide_js_exception(exc: Exception) -> bool:
+    try:
+        from pyodide.ffi import JsException
+    except ImportError:
+        return False
+    return isinstance(exc, JsException)
+
+
 def _load_cryptography_aead():
     """Return AES-GCM helpers if the runtime provides cryptography."""
-    global AESGCM, InvalidTag
-
-    AESGCM, InvalidTag = _import_cryptography_aead()
-    if AESGCM is not None and InvalidTag is not None:
+    if _cryptography_aead_available():
         return AESGCM, InvalidTag
 
     raise RuntimeError(
@@ -409,18 +427,34 @@ def _webcrypto_aesgcm_encrypt(key_bytes: bytes, nonce: bytes, plaintext: bytes) 
     algorithm = Object.fromEntries([["name", "AES-GCM"]])
     params = Object.fromEntries([["name", "AES-GCM"], ["iv", Uint8Array.new(nonce)]])
     usages = Array.of("encrypt", "decrypt")
-    crypto_key = run_sync(
-        crypto.subtle.importKey(
-            "raw",
-            Uint8Array.new(key_bytes),
-            algorithm,
-            False,
-            usages,
+    try:
+        crypto_key = run_sync(
+            crypto.subtle.importKey(
+                "raw",
+                Uint8Array.new(key_bytes),
+                algorithm,
+                False,
+                usages,
+            )
         )
-    )
-    encrypted = run_sync(
-        crypto.subtle.encrypt(params, crypto_key, Uint8Array.new(plaintext))
-    )
+    except Exception as exc:
+        if _is_pyodide_js_exception(exc):
+            raise RuntimeError(
+                "TOTP secret encryption requires the optional "
+                "'cryptography' package"
+            ) from exc
+        raise
+    try:
+        encrypted = run_sync(
+            crypto.subtle.encrypt(params, crypto_key, Uint8Array.new(plaintext))
+        )
+    except Exception as exc:
+        if _is_pyodide_js_exception(exc):
+            raise RuntimeError(
+                "TOTP secret encryption requires the optional "
+                "'cryptography' package"
+            ) from exc
+        raise
     return bytes(Uint8Array.new(encrypted).to_py())
 
 
@@ -443,18 +477,34 @@ def _webcrypto_aesgcm_decrypt(key_bytes: bytes, nonce: bytes, ciphertext: bytes)
     algorithm = Object.fromEntries([["name", "AES-GCM"]])
     params = Object.fromEntries([["name", "AES-GCM"], ["iv", Uint8Array.new(nonce)]])
     usages = Array.of("encrypt", "decrypt")
-    crypto_key = run_sync(
-        crypto.subtle.importKey(
-            "raw",
-            Uint8Array.new(key_bytes),
-            algorithm,
-            False,
-            usages,
+    try:
+        crypto_key = run_sync(
+            crypto.subtle.importKey(
+                "raw",
+                Uint8Array.new(key_bytes),
+                algorithm,
+                False,
+                usages,
+            )
         )
-    )
-    decrypted = run_sync(
-        crypto.subtle.decrypt(params, crypto_key, Uint8Array.new(ciphertext))
-    )
+    except Exception as exc:
+        if _is_pyodide_js_exception(exc):
+            raise RuntimeError(
+                "TOTP secret encryption requires the optional "
+                "'cryptography' package"
+            ) from exc
+        raise
+    try:
+        decrypted = run_sync(
+            crypto.subtle.decrypt(params, crypto_key, Uint8Array.new(ciphertext))
+        )
+    except Exception as exc:
+        if _is_pyodide_js_exception(exc):
+            raise RuntimeError(
+                "TOTP secret encryption requires the optional "
+                "'cryptography' package"
+            ) from exc
+        raise
     return bytes(Uint8Array.new(decrypted).to_py())
 
 
@@ -463,12 +513,10 @@ def encrypt_totp_secret(secret: str, encryption_key: str | Any) -> str:
     key = _resolve_totp_encryption_key(encryption_key)
     key_bytes = _derive_totp_aead_key(key)
     nonce = secrets.token_bytes(12)
-    try:
-        AESGCM, _ = _load_cryptography_aead()
-    except RuntimeError:
-        ciphertext = _webcrypto_aesgcm_encrypt(key_bytes, nonce, secret.encode())
-    else:
+    if _cryptography_aead_available():
         ciphertext = AESGCM(key_bytes).encrypt(nonce, secret.encode(), None)
+    else:
+        ciphertext = _webcrypto_aesgcm_encrypt(key_bytes, nonce, secret.encode())
     return base64.b64encode(nonce + ciphertext).decode()
 
 
@@ -489,10 +537,16 @@ def decrypt_totp_secret(
         key_bytes = _derive_totp_aead_key(key)
 
         if len(encrypted_bytes) >= 28:
-            try:
-                AESGCM, InvalidTag = _load_cryptography_aead()
-            except RuntimeError:
-                AESGCM = InvalidTag = None
+            if _cryptography_aead_available():
+                try:
+                    nonce, ciphertext = encrypted_bytes[:12], encrypted_bytes[12:]
+                    decrypted_bytes = AESGCM(key_bytes).decrypt(nonce, ciphertext, None)
+                    decrypted_secret = decrypted_bytes.decode()
+                    if _looks_like_totp_secret(decrypted_secret):
+                        return decrypted_secret
+                except (InvalidTag, ValueError):
+                    pass
+            else:
                 try:
                     nonce, ciphertext = encrypted_bytes[:12], encrypted_bytes[12:]
                     decrypted_bytes = _webcrypto_aesgcm_decrypt(
@@ -502,15 +556,6 @@ def decrypt_totp_secret(
                     if _looks_like_totp_secret(decrypted_secret):
                         return decrypted_secret
                 except (RuntimeError, ValueError, TypeError):
-                    pass
-            else:
-                try:
-                    nonce, ciphertext = encrypted_bytes[:12], encrypted_bytes[12:]
-                    decrypted_bytes = AESGCM(key_bytes).decrypt(nonce, ciphertext, None)
-                    decrypted_secret = decrypted_bytes.decode()
-                    if _looks_like_totp_secret(decrypted_secret):
-                        return decrypted_secret
-                except (InvalidTag, ValueError):
                     pass
 
         decrypted_secret = _decrypt_totp_secret_legacy(encrypted_bytes, key)

--- a/kinglet/totp.py
+++ b/kinglet/totp.py
@@ -507,8 +507,8 @@ def decrypt_totp_secret(
             else encrypted_secret
         )
         encrypted_bytes = base64.b64decode(encoded_secret)
-            if len(encrypted_bytes) < 8:
-                raise ValueError("Encrypted TOTP secret is too short")
+        if len(encrypted_bytes) < 8:
+            raise ValueError("Encrypted TOTP secret is too short")
         key = _resolve_totp_encryption_key(encryption_key)
         key_bytes = _derive_totp_aead_key(key)
 

--- a/kinglet/totp.py
+++ b/kinglet/totp.py
@@ -18,13 +18,13 @@ from typing import Any
 
 AESGCM = None
 InvalidTag = None
-TOTP_SECRET_ENCRYPTION_ERROR = (
+TOTP_ENCRYPTION_ERROR_MESSAGE = (
     "TOTP secret encryption requires the optional 'cryptography' package"
 )
 
 
-def _totp_secret_encryption_error() -> RuntimeError:
-    return RuntimeError(TOTP_SECRET_ENCRYPTION_ERROR)
+def _totp_encryption_error() -> RuntimeError:
+    return RuntimeError(TOTP_ENCRYPTION_ERROR_MESSAGE)
 
 
 def _import_cryptography_aead():
@@ -85,7 +85,7 @@ def _load_cryptography_aead():
     if _cryptography_aead_available():
         return AESGCM, InvalidTag
 
-    raise _totp_secret_encryption_error()
+    raise _totp_encryption_error()
 
 
 def _looks_like_totp_secret(secret: str) -> bool:
@@ -427,10 +427,10 @@ def _webcrypto_aesgcm_transform(
         from js import Array, Object, Uint8Array, crypto
         from pyodide.webloop import can_run_sync, run_sync
     except ImportError as exc:
-        raise _totp_secret_encryption_error() from exc
+        raise _totp_encryption_error() from exc
 
     if not can_run_sync():
-        raise _totp_secret_encryption_error()
+        raise _totp_encryption_error()
 
     algorithm = Object.fromEntries([["name", "AES-GCM"]])
     params = Object.fromEntries([["name", "AES-GCM"], ["iv", Uint8Array.new(nonce)]])
@@ -447,14 +447,14 @@ def _webcrypto_aesgcm_transform(
         )
     except Exception as exc:
         if _is_pyodide_js_exception(exc):
-            raise _totp_secret_encryption_error() from exc
+            raise _totp_encryption_error() from exc
         raise
     transform = getattr(crypto.subtle, operation)
     try:
         transformed = run_sync(transform(params, crypto_key, Uint8Array.new(payload)))
     except Exception as exc:
         if _is_pyodide_js_exception(exc):
-            raise _totp_secret_encryption_error() from exc
+            raise _totp_encryption_error() from exc
         raise
     return bytes(Uint8Array.new(transformed).to_py())
 

--- a/kinglet/totp.py
+++ b/kinglet/totp.py
@@ -18,6 +18,13 @@ from typing import Any
 
 AESGCM = None
 InvalidTag = None
+TOTP_SECRET_ENCRYPTION_ERROR = (
+    "TOTP secret encryption requires the optional 'cryptography' package"
+)
+
+
+def _totp_secret_encryption_error() -> RuntimeError:
+    return RuntimeError(TOTP_SECRET_ENCRYPTION_ERROR)
 
 
 def _import_cryptography_aead():
@@ -78,10 +85,7 @@ def _load_cryptography_aead():
     if _cryptography_aead_available():
         return AESGCM, InvalidTag
 
-    raise RuntimeError(
-        "TOTP secret encryption requires the optional "
-        "'cryptography' package"
-    )
+    raise _totp_secret_encryption_error()
 
 
 def _looks_like_totp_secret(secret: str) -> bool:
@@ -409,70 +413,24 @@ def _decrypt_totp_secret_legacy(encrypted_bytes: bytes, encryption_key: str) -> 
 
 
 def _webcrypto_aesgcm_encrypt(key_bytes: bytes, nonce: bytes, plaintext: bytes) -> bytes:
-    try:
-        from js import Array, Object, Uint8Array, crypto
-        from pyodide.webloop import can_run_sync, run_sync
-    except ImportError as exc:
-        raise RuntimeError(
-            "TOTP secret encryption requires the optional "
-            "'cryptography' package"
-        ) from exc
-
-    if not can_run_sync():
-        raise RuntimeError(
-            "TOTP secret encryption requires the optional "
-            "'cryptography' package"
-        )
-
-    algorithm = Object.fromEntries([["name", "AES-GCM"]])
-    params = Object.fromEntries([["name", "AES-GCM"], ["iv", Uint8Array.new(nonce)]])
-    usages = Array.of("encrypt", "decrypt")
-    try:
-        crypto_key = run_sync(
-            crypto.subtle.importKey(
-                "raw",
-                Uint8Array.new(key_bytes),
-                algorithm,
-                False,
-                usages,
-            )
-        )
-    except Exception as exc:
-        if _is_pyodide_js_exception(exc):
-            raise RuntimeError(
-                "TOTP secret encryption requires the optional "
-                "'cryptography' package"
-            ) from exc
-        raise
-    try:
-        encrypted = run_sync(
-            crypto.subtle.encrypt(params, crypto_key, Uint8Array.new(plaintext))
-        )
-    except Exception as exc:
-        if _is_pyodide_js_exception(exc):
-            raise RuntimeError(
-                "TOTP secret encryption requires the optional "
-                "'cryptography' package"
-            ) from exc
-        raise
-    return bytes(Uint8Array.new(encrypted).to_py())
+    return _webcrypto_aesgcm_transform("encrypt", key_bytes, nonce, plaintext)
 
 
 def _webcrypto_aesgcm_decrypt(key_bytes: bytes, nonce: bytes, ciphertext: bytes) -> bytes:
+    return _webcrypto_aesgcm_transform("decrypt", key_bytes, nonce, ciphertext)
+
+
+def _webcrypto_aesgcm_transform(
+    operation: str, key_bytes: bytes, nonce: bytes, payload: bytes
+) -> bytes:
     try:
         from js import Array, Object, Uint8Array, crypto
         from pyodide.webloop import can_run_sync, run_sync
     except ImportError as exc:
-        raise RuntimeError(
-            "TOTP secret encryption requires the optional "
-            "'cryptography' package"
-        ) from exc
+        raise _totp_secret_encryption_error() from exc
 
     if not can_run_sync():
-        raise RuntimeError(
-            "TOTP secret encryption requires the optional "
-            "'cryptography' package"
-        )
+        raise _totp_secret_encryption_error()
 
     algorithm = Object.fromEntries([["name", "AES-GCM"]])
     params = Object.fromEntries([["name", "AES-GCM"], ["iv", Uint8Array.new(nonce)]])
@@ -489,23 +447,16 @@ def _webcrypto_aesgcm_decrypt(key_bytes: bytes, nonce: bytes, ciphertext: bytes)
         )
     except Exception as exc:
         if _is_pyodide_js_exception(exc):
-            raise RuntimeError(
-                "TOTP secret encryption requires the optional "
-                "'cryptography' package"
-            ) from exc
+            raise _totp_secret_encryption_error() from exc
         raise
+    transform = getattr(crypto.subtle, operation)
     try:
-        decrypted = run_sync(
-            crypto.subtle.decrypt(params, crypto_key, Uint8Array.new(ciphertext))
-        )
+        transformed = run_sync(transform(params, crypto_key, Uint8Array.new(payload)))
     except Exception as exc:
         if _is_pyodide_js_exception(exc):
-            raise RuntimeError(
-                "TOTP secret encryption requires the optional "
-                "'cryptography' package"
-            ) from exc
+            raise _totp_secret_encryption_error() from exc
         raise
-    return bytes(Uint8Array.new(decrypted).to_py())
+    return bytes(Uint8Array.new(transformed).to_py())
 
 
 def encrypt_totp_secret(secret: str, encryption_key: str | Any) -> str:
@@ -520,6 +471,31 @@ def encrypt_totp_secret(secret: str, encryption_key: str | Any) -> str:
     return base64.b64encode(nonce + ciphertext).decode()
 
 
+def _decrypt_totp_secret_envelope(encrypted_bytes: bytes, key_bytes: bytes) -> str | None:
+    if len(encrypted_bytes) < 28:
+        return None
+
+    nonce, ciphertext = encrypted_bytes[:12], encrypted_bytes[12:]
+    if _cryptography_aead_available():
+        try:
+            decrypted_bytes = AESGCM(key_bytes).decrypt(nonce, ciphertext, None)
+        except (InvalidTag, ValueError):
+            return None
+    else:
+        try:
+            decrypted_bytes = _webcrypto_aesgcm_decrypt(key_bytes, nonce, ciphertext)
+        except (RuntimeError, ValueError, TypeError):
+            return None
+
+    try:
+        decrypted_secret = decrypted_bytes.decode()
+    except UnicodeDecodeError:
+        return None
+    if _looks_like_totp_secret(decrypted_secret):
+        return decrypted_secret
+    return None
+
+
 def decrypt_totp_secret(
     encrypted_secret: str | bytes, encryption_key: str | Any
 ) -> str:
@@ -531,32 +507,14 @@ def decrypt_totp_secret(
             else encrypted_secret
         )
         encrypted_bytes = base64.b64decode(encoded_secret)
-        if len(encrypted_bytes) < 8:
-            raise ValueError("Encrypted TOTP secret is too short")
+            if len(encrypted_bytes) < 8:
+                raise ValueError("Encrypted TOTP secret is too short")
         key = _resolve_totp_encryption_key(encryption_key)
         key_bytes = _derive_totp_aead_key(key)
 
-        if len(encrypted_bytes) >= 28:
-            if _cryptography_aead_available():
-                try:
-                    nonce, ciphertext = encrypted_bytes[:12], encrypted_bytes[12:]
-                    decrypted_bytes = AESGCM(key_bytes).decrypt(nonce, ciphertext, None)
-                    decrypted_secret = decrypted_bytes.decode()
-                    if _looks_like_totp_secret(decrypted_secret):
-                        return decrypted_secret
-                except (InvalidTag, ValueError):
-                    pass
-            else:
-                try:
-                    nonce, ciphertext = encrypted_bytes[:12], encrypted_bytes[12:]
-                    decrypted_bytes = _webcrypto_aesgcm_decrypt(
-                        key_bytes, nonce, ciphertext
-                    )
-                    decrypted_secret = decrypted_bytes.decode()
-                    if _looks_like_totp_secret(decrypted_secret):
-                        return decrypted_secret
-                except (RuntimeError, ValueError, TypeError):
-                    pass
+        decrypted_secret = _decrypt_totp_secret_envelope(encrypted_bytes, key_bytes)
+        if decrypted_secret is not None:
+            return decrypted_secret
 
         decrypted_secret = _decrypt_totp_secret_legacy(encrypted_bytes, key)
         if _looks_like_totp_secret(decrypted_secret):

--- a/kinglet/totp.py
+++ b/kinglet/totp.py
@@ -9,14 +9,28 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+import importlib
 import secrets
 import struct
 import time
 import urllib.parse
 from typing import Any
 
-from cryptography.exceptions import InvalidTag
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+AESGCM = None
+InvalidTag = None
+
+
+def _import_cryptography_aead():
+    try:
+        exc_mod = importlib.import_module("cryptography.exceptions")
+        aead_mod = importlib.import_module("cryptography.hazmat.primitives.ciphers.aead")
+    except ImportError:
+        return None, None
+
+    return aead_mod.AESGCM, exc_mod.InvalidTag
+
+
+AESGCM, InvalidTag = _import_cryptography_aead()
 
 # Test TOTP secret that generates predictable codes for development/testing
 # This secret will generate "000000" at Unix timestamp 0 (and cyclically)
@@ -36,6 +50,34 @@ def _env_get(env_source: Any, key: str, default=None):
     if isinstance(env_source, dict):
         return env_source.get(key, default)
     return getattr(env_source, key, default)
+
+
+def _load_cryptography_aead():
+    """Return AES-GCM helpers if the runtime provides cryptography."""
+    global AESGCM, InvalidTag
+
+    AESGCM, InvalidTag = _import_cryptography_aead()
+    if AESGCM is not None and InvalidTag is not None:
+        return AESGCM, InvalidTag
+
+    raise RuntimeError(
+        "TOTP secret encryption requires the optional "
+        "'cryptography' package"
+    )
+
+
+def _looks_like_totp_secret(secret: str) -> bool:
+    """Validate that a decrypted value still looks like a base32 TOTP secret."""
+    normalized = secret.replace(" ", "").replace("-", "").strip().upper()
+    if not normalized:
+        return False
+
+    padding_needed = (8 - len(normalized) % 8) % 8
+    try:
+        base64.b32decode(normalized + "=" * padding_needed)
+        return True
+    except Exception:
+        return False
 
 
 class OTPProvider:
@@ -313,10 +355,15 @@ def get_totp_encryption_key(env) -> str:
             "TOTP encryption key not configured: set TOTP_ENCRYPTION_KEY or JWT_SECRET"
         )
 
+    totp_key = str(totp_key)
+
     # In production, this should be a different key from JWT_SECRET
     # for defense in depth
     mode = str(_env_get(env, "MODE", "")).strip().lower()
-    if mode == "prod" and totp_key == _env_get(env, "JWT_SECRET", None):
+    jwt_secret = _env_get(env, "JWT_SECRET", None)
+    if jwt_secret is not None:
+        jwt_secret = str(jwt_secret)
+    if mode == "prod" and totp_key == jwt_secret:
         raise RuntimeError("TOTP_ENCRYPTION_KEY must differ from JWT_SECRET in prod")
 
     return totp_key
@@ -330,12 +377,12 @@ def _resolve_totp_encryption_key(encryption_key_or_env: str | Any) -> str:
 
 def _derive_totp_aead_key(encryption_key: str) -> bytes:
     """Derive a stable 256-bit AEAD key from the configured secret."""
-    return hashlib.sha256(encryption_key.encode()).digest()
+    return hashlib.sha256(str(encryption_key).encode()).digest()
 
 
 def _decrypt_totp_secret_legacy(encrypted_bytes: bytes, encryption_key: str) -> str:
     """Decrypt legacy XOR-based ciphertexts for backward compatibility."""
-    key_hash = hashlib.sha256(encryption_key.encode()).digest()
+    key_hash = hashlib.sha256(str(encryption_key).encode()).digest()
     decrypted_bytes = bytearray()
     for i, byte in enumerate(encrypted_bytes):
         key_byte = key_hash[i % len(key_hash)]
@@ -343,12 +390,85 @@ def _decrypt_totp_secret_legacy(encrypted_bytes: bytes, encryption_key: str) -> 
     return decrypted_bytes.decode()
 
 
+def _webcrypto_aesgcm_encrypt(key_bytes: bytes, nonce: bytes, plaintext: bytes) -> bytes:
+    try:
+        from js import Array, Object, Uint8Array, crypto
+        from pyodide.webloop import can_run_sync, run_sync
+    except ImportError as exc:
+        raise RuntimeError(
+            "TOTP secret encryption requires the optional "
+            "'cryptography' package"
+        ) from exc
+
+    if not can_run_sync():
+        raise RuntimeError(
+            "TOTP secret encryption requires the optional "
+            "'cryptography' package"
+        )
+
+    algorithm = Object.fromEntries([["name", "AES-GCM"]])
+    params = Object.fromEntries([["name", "AES-GCM"], ["iv", Uint8Array.new(nonce)]])
+    usages = Array.of("encrypt", "decrypt")
+    crypto_key = run_sync(
+        crypto.subtle.importKey(
+            "raw",
+            Uint8Array.new(key_bytes),
+            algorithm,
+            False,
+            usages,
+        )
+    )
+    encrypted = run_sync(
+        crypto.subtle.encrypt(params, crypto_key, Uint8Array.new(plaintext))
+    )
+    return bytes(Uint8Array.new(encrypted).to_py())
+
+
+def _webcrypto_aesgcm_decrypt(key_bytes: bytes, nonce: bytes, ciphertext: bytes) -> bytes:
+    try:
+        from js import Array, Object, Uint8Array, crypto
+        from pyodide.webloop import can_run_sync, run_sync
+    except ImportError as exc:
+        raise RuntimeError(
+            "TOTP secret encryption requires the optional "
+            "'cryptography' package"
+        ) from exc
+
+    if not can_run_sync():
+        raise RuntimeError(
+            "TOTP secret encryption requires the optional "
+            "'cryptography' package"
+        )
+
+    algorithm = Object.fromEntries([["name", "AES-GCM"]])
+    params = Object.fromEntries([["name", "AES-GCM"], ["iv", Uint8Array.new(nonce)]])
+    usages = Array.of("encrypt", "decrypt")
+    crypto_key = run_sync(
+        crypto.subtle.importKey(
+            "raw",
+            Uint8Array.new(key_bytes),
+            algorithm,
+            False,
+            usages,
+        )
+    )
+    decrypted = run_sync(
+        crypto.subtle.decrypt(params, crypto_key, Uint8Array.new(ciphertext))
+    )
+    return bytes(Uint8Array.new(decrypted).to_py())
+
+
 def encrypt_totp_secret(secret: str, encryption_key: str | Any) -> str:
     """Encrypt TOTP secret for database storage"""
     key = _resolve_totp_encryption_key(encryption_key)
     key_bytes = _derive_totp_aead_key(key)
     nonce = secrets.token_bytes(12)
-    ciphertext = AESGCM(key_bytes).encrypt(nonce, secret.encode(), None)
+    try:
+        AESGCM, _ = _load_cryptography_aead()
+    except RuntimeError:
+        ciphertext = _webcrypto_aesgcm_encrypt(key_bytes, nonce, secret.encode())
+    else:
+        ciphertext = AESGCM(key_bytes).encrypt(nonce, secret.encode(), None)
     return base64.b64encode(nonce + ciphertext).decode()
 
 
@@ -370,14 +490,34 @@ def decrypt_totp_secret(
 
         if len(encrypted_bytes) >= 28:
             try:
-                nonce, ciphertext = encrypted_bytes[:12], encrypted_bytes[12:]
-                decrypted_bytes = AESGCM(key_bytes).decrypt(nonce, ciphertext, None)
-                return decrypted_bytes.decode()
-            except (InvalidTag, ValueError):
-                pass
+                AESGCM, InvalidTag = _load_cryptography_aead()
+            except RuntimeError:
+                AESGCM = InvalidTag = None
+                try:
+                    nonce, ciphertext = encrypted_bytes[:12], encrypted_bytes[12:]
+                    decrypted_bytes = _webcrypto_aesgcm_decrypt(
+                        key_bytes, nonce, ciphertext
+                    )
+                    decrypted_secret = decrypted_bytes.decode()
+                    if _looks_like_totp_secret(decrypted_secret):
+                        return decrypted_secret
+                except (RuntimeError, ValueError, TypeError):
+                    pass
+            else:
+                try:
+                    nonce, ciphertext = encrypted_bytes[:12], encrypted_bytes[12:]
+                    decrypted_bytes = AESGCM(key_bytes).decrypt(nonce, ciphertext, None)
+                    decrypted_secret = decrypted_bytes.decode()
+                    if _looks_like_totp_secret(decrypted_secret):
+                        return decrypted_secret
+                except (InvalidTag, ValueError):
+                    pass
 
-        return _decrypt_totp_secret_legacy(encrypted_bytes, key)
-    except (InvalidTag, ValueError, RuntimeError, TypeError) as e:
+        decrypted_secret = _decrypt_totp_secret_legacy(encrypted_bytes, key)
+        if _looks_like_totp_secret(decrypted_secret):
+            return decrypted_secret
+        raise ValueError("Failed to decrypt TOTP secret")
+    except (ValueError, RuntimeError, TypeError) as e:
         raise ValueError("Failed to decrypt TOTP secret") from e
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kinglet"
-version = "1.8.2"
+version = "1.9.0"
 description = "A lightweight routing framework for Python Workers"
 readme = "README.md"
 authors = [
@@ -26,7 +26,7 @@ classifiers = [
 keywords = ["cloudflare", "workers", "python", "routing", "web", "framework", "asgi", "lightweight"]
 requires-python = ">=3.12"
 dependencies = [
-    "cryptography>=46.0.7",
+    "cryptography>=46.0.7; sys_platform != 'emscripten'",
 ]
 
 [project.scripts]
@@ -38,7 +38,11 @@ Repository = "https://github.com/mitchins/Kinglet"
 "Bug Tracker" = "https://github.com/mitchins/Kinglet/issues"
 
 [project.optional-dependencies]
+crypto = [
+    "cryptography>=46.0.7; sys_platform != 'emscripten'",
+]
 dev = [
+    "cryptography>=46.0.7",
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
     "pytest-cov>=4.0",
@@ -51,6 +55,7 @@ dev = [
     "pre-commit>=3.0.0",
 ]
 test = [
+    "cryptography>=46.0.7",
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
     "pytest-cov>=4.0",
@@ -128,8 +133,10 @@ disallow_incomplete_defs = true
 
 [dependency-groups]
 dev = [
+    "cryptography>=46.0.7",
     "diff-cover>=9.6.0",
     "pre-commit>=4.3.0",
+    "pytest-asyncio>=0.21",
     "pytest-cov>=6.2.1",
     "ruff>=0.12.10",
     "httpx>=0.27.0",

--- a/scripts/pywrangler-clean-deploy.sh
+++ b/scripts/pywrangler-clean-deploy.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+demo_dir="$(cd "$script_dir/../examples/totp_workers_demo" && pwd)"
+
+cd "$demo_dir"
+
+if [[ ! -f wrangler.toml ]]; then
+  echo "wrangler.toml not found in $demo_dir" >&2
+  exit 1
+fi
+
 rm -rf .venv-workers python_modules vendor
 uv lock --refresh
 uv sync --group dev --refresh-package kinglet --reinstall-package kinglet

--- a/scripts/pywrangler-clean-deploy.sh
+++ b/scripts/pywrangler-clean-deploy.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+rm -rf .venv-workers python_modules vendor
+uv lock --refresh
+uv sync --group dev --refresh-package kinglet --reinstall-package kinglet
+uv run pywrangler sync --force
+
+echo "Checking packaged Kinglet source..."
+uv run python - <<'PY'
+from pathlib import Path
+
+p = Path("python_modules/kinglet")
+assert p.exists(), "python_modules/kinglet missing"
+print("Packaged Kinglet files:", len(list(p.rglob("*.py"))))
+PY
+
+uv run pywrangler deploy "$@"

--- a/tests/test_init_imports.py
+++ b/tests/test_init_imports.py
@@ -2,7 +2,10 @@
 Tests for kinglet __init__.py import handling
 """
 
+import importlib
+import runpy
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 
@@ -74,7 +77,7 @@ class TestImportFallbacks:
         assert hasattr(kinglet, "__author__")
         assert hasattr(kinglet, "__all__")
 
-        assert kinglet.__version__ == "1.8.2"  # Current version
+        assert kinglet.__version__ == "1.9.0"  # Current version
         assert kinglet.__author__ == "Mitchell Currie"
         assert isinstance(kinglet.__all__, list)
         assert len(kinglet.__all__) > 0
@@ -103,3 +106,47 @@ class TestImportFallbacks:
             else:
                 # ORM items should be present if ORM is available
                 assert "Model" in kinglet.__all__
+
+    def test_examples_import_without_cryptography(self):
+        """Auth and TOTP example modules should load without eager crypto imports."""
+        blocked_modules = {
+            "cryptography": None,
+            "cryptography.exceptions": None,
+            "cryptography.hazmat": None,
+            "cryptography.hazmat.primitives": None,
+            "cryptography.hazmat.primitives.ciphers": None,
+            "cryptography.hazmat.primitives.ciphers.aead": None,
+        }
+        examples_dir = Path(__file__).resolve().parent.parent / "examples"
+
+        with patch.dict(sys.modules, blocked_modules, clear=False):
+            for module in [
+                "kinglet",
+                "kinglet.authz",
+                "kinglet.totp",
+            ]:
+                sys.modules.pop(module, None)
+
+            kinglet = importlib.import_module("kinglet")
+            assert kinglet.Kinglet is not None
+
+            totp_module = kinglet.totp
+            code = totp_module.generate_totp_code("JBSWY3DPEHPK3PXP", timestamp=0)
+            assert len(code) == 6
+            assert code.isdigit()
+
+            basic_api_globals = runpy.run_path(str(examples_dir / "basic_api.py"))
+            assert "app" in basic_api_globals
+
+            authz_globals = runpy.run_path(str(examples_dir / "authz_example.py"))
+            assert "router" in authz_globals
+
+            totp_globals = runpy.run_path(str(examples_dir / "totp_example.py"))
+            assert "app" in totp_globals
+
+            workers_demo_globals = runpy.run_path(
+                str(examples_dir / "totp_workers_demo" / "worker.py")
+            )
+            assert "app" in workers_demo_globals
+            assert "Default" in workers_demo_globals
+            assert hasattr(workers_demo_globals["Default"], "fetch")

--- a/tests/test_totp_env_key.py
+++ b/tests/test_totp_env_key.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
+import kinglet.totp as totp
 from kinglet.totp import (
     decrypt_totp_secret,
     encrypt_totp_secret,
@@ -56,6 +57,10 @@ class _FakeObject:
         return {key: value for key, value in entries}
 
 
+class _FakeJsException(Exception):
+    pass
+
+
 class _FakeSubtleCrypto:
     def importKey(self, format_name, key_data, algorithm, extractable, usages):
         assert format_name == "raw"
@@ -70,7 +75,7 @@ class _FakeSubtleCrypto:
         return AESGCM(crypto_key).decrypt(bytes(params["iv"].to_py()), bytes(data.to_py()), None)
 
 
-def _fake_workers_webcrypto_modules():
+def _fake_workers_webcrypto_modules(*, can_run_sync=True):
     js_module = ModuleType("js")
     js_module.Array = _FakeArray
     js_module.Object = _FakeObject
@@ -78,14 +83,18 @@ def _fake_workers_webcrypto_modules():
     js_module.crypto = SimpleNamespace(subtle=_FakeSubtleCrypto())
 
     pyodide_module = ModuleType("pyodide")
+    ffi_module = ModuleType("pyodide.ffi")
+    ffi_module.JsException = _FakeJsException
     webloop_module = ModuleType("pyodide.webloop")
-    webloop_module.can_run_sync = lambda: True
+    webloop_module.can_run_sync = lambda: can_run_sync
     webloop_module.run_sync = lambda value: value
+    pyodide_module.ffi = ffi_module
     pyodide_module.webloop = webloop_module
 
     return {
         "js": js_module,
         "pyodide": pyodide_module,
+        "pyodide.ffi": ffi_module,
         "pyodide.webloop": webloop_module,
     }
 
@@ -150,6 +159,83 @@ def test_workers_webcrypto_backend_encrypts_and_decrypts_round_trip():
         assert decrypt_totp_secret(encrypted, env) == secret
 
 
+def test_cryptography_backend_probe_caches_missing_backend():
+    original_aesgcm = totp.AESGCM
+    original_invalid_tag = totp.InvalidTag
+    try:
+        totp.AESGCM = None
+        totp.InvalidTag = None
+
+        with patch.object(totp.importlib, "import_module", side_effect=ImportError):
+            assert totp._cryptography_aead_available() is False
+            assert totp.AESGCM is False
+            assert totp.InvalidTag is False
+    finally:
+        totp.AESGCM = original_aesgcm
+        totp.InvalidTag = original_invalid_tag
+
+
+def test_load_cryptography_aead_requires_backend():
+    with patch.object(totp, "_cryptography_aead_available", return_value=False):
+        with pytest.raises(RuntimeError, match="optional 'cryptography' package"):
+            totp._load_cryptography_aead()
+
+
+def test_webcrypto_backend_import_failure_raises_optional_crypto_error():
+    with patch.dict(
+        sys.modules,
+        {"js": None, "pyodide": None, "pyodide.ffi": None, "pyodide.webloop": None},
+        clear=False,
+    ):
+        with pytest.raises(RuntimeError, match="optional 'cryptography' package"):
+            totp._webcrypto_aesgcm_encrypt(b"0" * 32, b"0" * 12, b"payload")
+
+
+def test_workers_webcrypto_backend_rejects_non_sync_runtime():
+    env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
+
+    with patch.object(totp, "_cryptography_aead_available", return_value=False), patch.dict(
+        sys.modules, _fake_workers_webcrypto_modules(can_run_sync=False), clear=False
+    ):
+        with pytest.raises(RuntimeError, match="optional 'cryptography' package"):
+            encrypt_totp_secret("JBSWY3DPEHPK3PXP", env)
+
+
+def test_workers_webcrypto_backend_translates_js_exception():
+    env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
+
+    class _ExplodingSubtleCrypto(_FakeSubtleCrypto):
+        def encrypt(self, params, crypto_key, data):
+            raise _FakeJsException("boom")
+
+    modules = _fake_workers_webcrypto_modules()
+    modules["js"].crypto = SimpleNamespace(subtle=_ExplodingSubtleCrypto())
+
+    with patch.object(totp, "_cryptography_aead_available", return_value=False), patch.dict(
+        sys.modules, modules, clear=False
+    ):
+        with pytest.raises(RuntimeError, match="optional 'cryptography' package"):
+            encrypt_totp_secret("JBSWY3DPEHPK3PXP", env)
+
+
+def test_workers_webcrypto_backend_translates_js_exception_on_decrypt():
+    env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
+    encrypted = encrypt_totp_secret("JBSWY3DPEHPK3PXP", env)
+
+    class _ExplodingSubtleCrypto(_FakeSubtleCrypto):
+        def decrypt(self, params, crypto_key, data):
+            raise _FakeJsException("boom")
+
+    modules = _fake_workers_webcrypto_modules()
+    modules["js"].crypto = SimpleNamespace(subtle=_ExplodingSubtleCrypto())
+
+    with patch.object(totp, "_cryptography_aead_available", return_value=False), patch.dict(
+        sys.modules, modules, clear=False
+    ), patch.object(totp, "_decrypt_totp_secret_legacy", return_value="not-a-secret"):
+        with pytest.raises(ValueError, match="Failed to decrypt TOTP secret"):
+            decrypt_totp_secret(encrypted, env)
+
+
 def test_totp_ciphertext_envelope_is_base64_nonce_plus_ciphertext():
     env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
     secret = "JBSWY3DPEHPK3PXP"
@@ -167,6 +253,25 @@ def test_decrypt_totp_secret_supports_legacy_ciphertext():
     env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
 
     assert decrypt_totp_secret(legacy_ciphertext, env) == secret
+
+
+def test_decrypt_totp_secret_rejects_too_short_ciphertext():
+    env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
+
+    with pytest.raises(ValueError, match="Failed to decrypt TOTP secret"):
+        decrypt_totp_secret("AAAA", env)
+
+
+def test_decrypt_totp_secret_rejects_invalid_envelope_payload():
+    env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
+    key_bytes = hashlib.sha256(env.TOTP_ENCRYPTION_KEY.encode()).digest()
+    nonce = b"0123456789ab"
+    ciphertext = AESGCM(key_bytes).encrypt(nonce, b"not-a-secret", None)
+    encrypted = base64.b64encode(nonce + ciphertext).decode()
+
+    with patch.object(totp, "_decrypt_totp_secret_legacy", return_value="not-a-secret"):
+        with pytest.raises(ValueError, match="Failed to decrypt TOTP secret"):
+            decrypt_totp_secret(encrypted, env)
 
 
 def test_old_totp_fixture_decrypts_under_1_9_0():

--- a/tests/test_totp_env_key.py
+++ b/tests/test_totp_env_key.py
@@ -231,7 +231,7 @@ def test_workers_webcrypto_backend_translates_js_exception_on_decrypt():
 
     with patch.object(totp, "_cryptography_aead_available", return_value=False), patch.dict(
         sys.modules, modules, clear=False
-    ), patch.object(totp, "_decrypt_totp_secret_legacy", return_value="not-a-secret"):
+    ), patch.object(totp, "_decrypt_totp_secret_legacy", return_value="not-a-secret!"):
         with pytest.raises(ValueError, match="Failed to decrypt TOTP secret"):
             decrypt_totp_secret(encrypted, env)
 
@@ -266,10 +266,10 @@ def test_decrypt_totp_secret_rejects_invalid_envelope_payload():
     env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
     key_bytes = hashlib.sha256(env.TOTP_ENCRYPTION_KEY.encode()).digest()
     nonce = b"0123456789ab"
-    ciphertext = AESGCM(key_bytes).encrypt(nonce, b"not-a-secret", None)
+    ciphertext = AESGCM(key_bytes).encrypt(nonce, b"not-a-secret!", None)
     encrypted = base64.b64encode(nonce + ciphertext).decode()
 
-    with patch.object(totp, "_decrypt_totp_secret_legacy", return_value="not-a-secret"):
+    with patch.object(totp, "_decrypt_totp_secret_legacy", return_value="not-a-secret!"):
         with pytest.raises(ValueError, match="Failed to decrypt TOTP secret"):
             decrypt_totp_secret(encrypted, env)
 

--- a/tests/test_totp_env_key.py
+++ b/tests/test_totp_env_key.py
@@ -144,10 +144,7 @@ def test_workers_webcrypto_backend_encrypts_and_decrypts_round_trip():
     secret = "JBSWY3DPEHPK3PXP"
 
     with patch(
-        "kinglet.totp._load_cryptography_aead",
-        side_effect=RuntimeError(
-            "TOTP secret encryption requires the optional 'cryptography' package"
-        ),
+        "kinglet.totp._cryptography_aead_available", return_value=False
     ), patch.dict(sys.modules, _fake_workers_webcrypto_modules(), clear=False):
         encrypted = encrypt_totp_secret(secret, env)
         assert decrypt_totp_secret(encrypted, env) == secret
@@ -178,19 +175,6 @@ def test_old_totp_fixture_decrypts_under_1_9_0():
     env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
 
     assert decrypt_totp_secret(legacy_ciphertext, env) == secret
-
-
-def test_encrypt_totp_secret_requires_cryptography_dependency():
-    env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
-
-    with patch(
-        "kinglet.totp._load_cryptography_aead",
-        side_effect=RuntimeError(
-            "TOTP secret encryption requires the optional 'cryptography' package"
-        ),
-    ):
-        with pytest.raises(RuntimeError, match="optional 'cryptography' package"):
-            encrypt_totp_secret("JBSWY3DPEHPK3PXP", env)
 
 
 def test_base_import_works_without_cryptography_on_emscripten():
@@ -231,10 +215,7 @@ def test_encrypt_totp_secret_errors_when_no_backend_exists():
     env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
 
     with patch(
-        "kinglet.totp._load_cryptography_aead",
-        side_effect=RuntimeError(
-            "TOTP secret encryption requires the optional 'cryptography' package"
-        ),
+        "kinglet.totp._cryptography_aead_available", return_value=False
     ), patch(
         "kinglet.totp._webcrypto_aesgcm_encrypt",
         side_effect=RuntimeError(
@@ -251,9 +232,6 @@ def test_decrypt_legacy_ciphertext_without_cryptography():
     env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
 
     with patch(
-        "kinglet.totp._load_cryptography_aead",
-        side_effect=RuntimeError(
-            "TOTP secret encryption requires the optional 'cryptography' package"
-        ),
+        "kinglet.totp._cryptography_aead_available", return_value=False
     ):
         assert decrypt_totp_secret(legacy_ciphertext, env) == secret

--- a/tests/test_totp_env_key.py
+++ b/tests/test_totp_env_key.py
@@ -1,14 +1,22 @@
 import base64
 import hashlib
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 from kinglet.totp import (
     decrypt_totp_secret,
     encrypt_totp_secret,
     get_totp_encryption_key,
 )
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def _encrypt_totp_secret_legacy(secret: str, encryption_key: str) -> str:
@@ -17,6 +25,69 @@ def _encrypt_totp_secret_legacy(secret: str, encryption_key: str) -> str:
     for i, byte in enumerate(secret.encode()):
         encrypted.append(byte ^ key_hash[i % len(key_hash)])
     return base64.b64encode(bytes(encrypted)).decode()
+
+
+class _FakeUint8Array:
+    def __init__(self, data):
+        if isinstance(data, _FakeUint8Array):
+            self._bytes = data._bytes
+        elif isinstance(data, (bytes, bytearray, memoryview)):
+            self._bytes = bytes(data)
+        else:
+            self._bytes = bytes(data)
+
+    @classmethod
+    def new(cls, data):
+        return cls(data)
+
+    def to_py(self):
+        return list(self._bytes)
+
+
+class _FakeArray:
+    @staticmethod
+    def of(*values):
+        return list(values)
+
+
+class _FakeObject:
+    @staticmethod
+    def fromEntries(entries):
+        return {key: value for key, value in entries}
+
+
+class _FakeSubtleCrypto:
+    def importKey(self, format_name, key_data, algorithm, extractable, usages):
+        assert format_name == "raw"
+        assert algorithm["name"] == "AES-GCM"
+        assert list(usages) == ["encrypt", "decrypt"]
+        return bytes(key_data.to_py())
+
+    def encrypt(self, params, crypto_key, data):
+        return AESGCM(crypto_key).encrypt(bytes(params["iv"].to_py()), bytes(data.to_py()), None)
+
+    def decrypt(self, params, crypto_key, data):
+        return AESGCM(crypto_key).decrypt(bytes(params["iv"].to_py()), bytes(data.to_py()), None)
+
+
+def _fake_workers_webcrypto_modules():
+    js_module = ModuleType("js")
+    js_module.Array = _FakeArray
+    js_module.Object = _FakeObject
+    js_module.Uint8Array = _FakeUint8Array
+    js_module.crypto = SimpleNamespace(subtle=_FakeSubtleCrypto())
+
+    pyodide_module = ModuleType("pyodide")
+    webloop_module = ModuleType("pyodide.webloop")
+    webloop_module.can_run_sync = lambda: True
+    webloop_module.run_sync = lambda value: value
+    pyodide_module.webloop = webloop_module
+
+    return {
+        "js": js_module,
+        "pyodide": pyodide_module,
+        "pyodide.webloop": webloop_module,
+    }
 
 
 def test_get_totp_encryption_key_fallback_to_jwt_secret():
@@ -57,9 +128,132 @@ def test_totp_secret_round_trip_accepts_dict_env():
     assert decrypt_totp_secret(encrypted, env) == secret
 
 
+def test_standard_python_cryptography_backend_encrypts_and_decrypts_round_trip():
+    env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
+    secret = "JBSWY3DPEHPK3PXP"
+
+    with patch("kinglet.totp._webcrypto_aesgcm_encrypt", side_effect=AssertionError), patch(
+        "kinglet.totp._webcrypto_aesgcm_decrypt", side_effect=AssertionError
+    ):
+        encrypted = encrypt_totp_secret(secret, env)
+        assert decrypt_totp_secret(encrypted, env) == secret
+
+
+def test_workers_webcrypto_backend_encrypts_and_decrypts_round_trip():
+    env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
+    secret = "JBSWY3DPEHPK3PXP"
+
+    with patch(
+        "kinglet.totp._load_cryptography_aead",
+        side_effect=RuntimeError(
+            "TOTP secret encryption requires the optional 'cryptography' package"
+        ),
+    ), patch.dict(sys.modules, _fake_workers_webcrypto_modules(), clear=False):
+        encrypted = encrypt_totp_secret(secret, env)
+        assert decrypt_totp_secret(encrypted, env) == secret
+
+
+def test_totp_ciphertext_envelope_is_base64_nonce_plus_ciphertext():
+    env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
+    secret = "JBSWY3DPEHPK3PXP"
+
+    encrypted = encrypt_totp_secret(secret, env)
+    decoded = base64.b64decode(encrypted)
+
+    assert len(decoded) == 12 + len(secret.encode()) + 16
+    assert base64.b64encode(decoded).decode() == encrypted
+
+
 def test_decrypt_totp_secret_supports_legacy_ciphertext():
     secret = "JBSWY3DPEHPK3PXP"
     legacy_ciphertext = _encrypt_totp_secret_legacy(secret, "totp-secret-value")
     env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
 
     assert decrypt_totp_secret(legacy_ciphertext, env) == secret
+
+
+def test_old_totp_fixture_decrypts_under_1_9_0():
+    secret = "JBSWY3DPEHPK3PXP"
+    legacy_ciphertext = _encrypt_totp_secret_legacy(secret, "totp-secret-value")
+    env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
+
+    assert decrypt_totp_secret(legacy_ciphertext, env) == secret
+
+
+def test_encrypt_totp_secret_requires_cryptography_dependency():
+    env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
+
+    with patch(
+        "kinglet.totp._load_cryptography_aead",
+        side_effect=RuntimeError(
+            "TOTP secret encryption requires the optional 'cryptography' package"
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="optional 'cryptography' package"):
+            encrypt_totp_secret("JBSWY3DPEHPK3PXP", env)
+
+
+def test_base_import_works_without_cryptography_on_emscripten():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import builtins
+import sys
+
+real_import = builtins.__import__
+
+def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "cryptography" or name.startswith("cryptography."):
+        raise ImportError("blocked for emscripten import test")
+    return real_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = blocked_import
+sys.platform = "emscripten"
+
+import kinglet
+
+print(kinglet.Kinglet.__name__)
+""",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "Kinglet"
+
+
+def test_encrypt_totp_secret_errors_when_no_backend_exists():
+    env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
+
+    with patch(
+        "kinglet.totp._load_cryptography_aead",
+        side_effect=RuntimeError(
+            "TOTP secret encryption requires the optional 'cryptography' package"
+        ),
+    ), patch(
+        "kinglet.totp._webcrypto_aesgcm_encrypt",
+        side_effect=RuntimeError(
+            "TOTP secret encryption requires the optional 'cryptography' package"
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="optional 'cryptography' package"):
+            encrypt_totp_secret("JBSWY3DPEHPK3PXP", env)
+
+
+def test_decrypt_legacy_ciphertext_without_cryptography():
+    secret = "JBSWY3DPEHPK3PXP"
+    legacy_ciphertext = _encrypt_totp_secret_legacy(secret, "totp-secret-value")
+    env = SimpleNamespace(TOTP_ENCRYPTION_KEY="totp-secret-value")
+
+    with patch(
+        "kinglet.totp._load_cryptography_aead",
+        side_effect=RuntimeError(
+            "TOTP secret encryption requires the optional 'cryptography' package"
+        ),
+    ):
+        assert decrypt_totp_secret(legacy_ciphertext, env) == secret

--- a/uv.lock
+++ b/uv.lock
@@ -560,16 +560,20 @@ wheels = [
 
 [[package]]
 name = "kinglet"
-version = "1.8.2"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
-    { name = "cryptography" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten'" },
 ]
 
 [package.optional-dependencies]
+crypto = [
+    { name = "cryptography", marker = "sys_platform != 'emscripten'" },
+]
 dev = [
     { name = "bandit" },
     { name = "black" },
+    { name = "cryptography" },
     { name = "httpx" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -581,6 +585,7 @@ dev = [
 ]
 test = [
     { name = "coverage" },
+    { name = "cryptography" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -589,10 +594,12 @@ test = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "cryptography" },
     { name = "diff-cover" },
     { name = "httpx" },
     { name = "keyring" },
     { name = "pre-commit" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
@@ -602,7 +609,10 @@ requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=22.0" },
     { name = "coverage", marker = "extra == 'test'", specifier = ">=6.0" },
-    { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten'", specifier = ">=46.0.7" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and extra == 'crypto'", specifier = ">=46.0.7" },
+    { name = "cryptography", marker = "extra == 'dev'", specifier = ">=46.0.7" },
+    { name = "cryptography", marker = "extra == 'test'", specifier = ">=46.0.7" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
@@ -616,14 +626,16 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "safety", marker = "extra == 'dev'", specifier = ">=2.0.0" },
 ]
-provides-extras = ["dev", "test"]
+provides-extras = ["crypto", "dev", "test"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "cryptography", specifier = ">=46.0.7" },
     { name = "diff-cover", specifier = ">=9.6.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "keyring", specifier = ">=25.7.0" },
     { name = "pre-commit", specifier = ">=4.3.0" },
+    { name = "pytest-asyncio", specifier = ">=0.21" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "ruff", specifier = ">=0.12.10" },
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloudflare Workers TOTP demo and deployment-ready example added; package version bumped to 1.9.0 and TOTP is lazily loaded.

* **Improvements**
  * AES‑GCM-based TOTP secret encryption with robust cross‑environment fallbacks, validation, and consistent error handling.
  * Example API responses and example test runner assertions clarified.

* **Documentation**
  * Expanded TOTP docs and Examples README with Workers demo guidance.

* **Tests**
  * Broadened test coverage for TOTP encryption backends and import compatibility without native crypto.

* **Chores**
  * Added clean deploy script and Workers demo packaging/config updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->