### PR TITLE
[codex] Fix route decorator security bypasses

### DIFF
--- a/kinglet/authz.py
+++ b/kinglet/authz.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import base64
+import functools
 import hashlib
 import hmac
 import json
@@ -161,6 +162,7 @@ async def r2_media_owner(env, bucket_binding: str, key: str) -> dict | None:
 
 # ---------- Decorators ----------
 def require_auth(handler: Callable[[Any], Awaitable[Any]]):
+    @functools.wraps(handler)
     async def wrapped(req):
         user = await get_user(req)
         if not user:
@@ -183,6 +185,7 @@ def allow_public_or_owner(
     """
 
     def deco(handler):
+        @functools.wraps(handler)
         async def wrapped(req):
             rid = req.path_param(id_param)
             rec = await load_fn(req, rid)
@@ -212,6 +215,7 @@ def require_owner(
     allow_admin_env="ADMIN_IDS",
 ):
     def deco(handler):
+        @functools.wraps(handler)
         async def wrapped(req):
             user = await get_user(req)
             if not user:
@@ -243,6 +247,7 @@ def require_participant(
     allow_admin_env="ADMIN_IDS",
 ):
     def deco(handler):
+        @functools.wraps(handler)
         async def wrapped(req):
             user = await get_user(req)
             if not user:
@@ -270,6 +275,7 @@ def require_participant(
 def require_elevated_session(handler: Callable[[Any], Awaitable[Any]]):
     """Require elevated session (TOTP verified) - skips if TOTP_ENABLED=false"""
 
+    @functools.wraps(handler)
     async def wrapped(req):
         user = await get_user(req)
         if not user:
@@ -320,6 +326,7 @@ def require_claim(claim_name: str, claim_value: Any = True):
     """Require specific claim in JWT (app-specific like 'publisher', 'host')"""
 
     def deco(handler):
+        @functools.wraps(handler)
         async def wrapped(req):
             user = await get_user(req)
             if not user:
@@ -352,6 +359,7 @@ def require_elevated_claim(claim_name: str, claim_value: Any = True):
     """Require both elevated session AND specific claim - skips elevation if TOTP_ENABLED=false"""
 
     def deco(handler):
+        @functools.wraps(handler)
         async def wrapped(req):
             user = await get_user(req)
             if not user:

--- a/kinglet/core.py
+++ b/kinglet/core.py
@@ -22,7 +22,7 @@ class Route:
         self.handler_module = getattr(handler, "__module__", None)
         self.handler_name = getattr(handler, "__name__", None)
         self.methods = [m.upper() for m in methods]
-        self._last_resolved_candidate_id: int | None = None
+        self._last_resolved_candidate: Callable | None = None
         self._last_resolved_candidate_matches = False
 
         # Convert path to regex with parameter extraction
@@ -47,15 +47,14 @@ class Route:
         if not callable(candidate) or candidate is current_handler:
             return current_handler
 
-        candidate_id = id(candidate)
-        if candidate_id == self._last_resolved_candidate_id:
+        if candidate is self._last_resolved_candidate:
             if self._last_resolved_candidate_matches:
                 self._handler = candidate
                 return candidate
             return current_handler
 
         matches = self._references_handler(candidate, current_handler)
-        self._last_resolved_candidate_id = candidate_id
+        self._last_resolved_candidate = candidate
         self._last_resolved_candidate_matches = matches
         if matches:
             self._handler = candidate

--- a/kinglet/core.py
+++ b/kinglet/core.py
@@ -22,6 +22,8 @@ class Route:
         self.handler_module = getattr(handler, "__module__", None)
         self.handler_name = getattr(handler, "__name__", None)
         self.methods = [m.upper() for m in methods]
+        self._last_resolved_candidate_id: int | None = None
+        self._last_resolved_candidate_matches = False
 
         # Convert path to regex with parameter extraction
         self.regex, self.param_names = self._compile_path(path)
@@ -29,9 +31,9 @@ class Route:
     def _resolve_handler(self) -> Callable:
         """Return the callable registered for this route.
 
-        If the module-level name now refers to a wrapper around the originally
-        registered handler, keep the wrapper so decorator order remains
-        supported without swapping in unrelated same-named callables.
+        Only upgrade to a same-named module wrapper when it still references
+        the registered handler. This preserves support for external decorators
+        without swapping in unrelated callables.
         """
         current_handler = self._handler
         if not self.handler_module or not self.handler_name:
@@ -45,7 +47,17 @@ class Route:
         if not callable(candidate) or candidate is current_handler:
             return current_handler
 
-        if self._references_handler(candidate, current_handler):
+        candidate_id = id(candidate)
+        if candidate_id == self._last_resolved_candidate_id:
+            if self._last_resolved_candidate_matches:
+                self._handler = candidate
+                return candidate
+            return current_handler
+
+        matches = self._references_handler(candidate, current_handler)
+        self._last_resolved_candidate_id = candidate_id
+        self._last_resolved_candidate_matches = matches
+        if matches:
             self._handler = candidate
             return candidate
 
@@ -53,50 +65,57 @@ class Route:
 
     def _references_handler(self, candidate: Callable, handler: Callable) -> bool:
         """Check whether a callable still references the registered handler."""
-        current = candidate
-        seen_ids: set[int] = set()
+        return self._object_references_value(candidate, handler, set())
 
-        while True:
-            wrapped = getattr(current, "__wrapped__", None)
-            if wrapped is None:
-                break
-            if wrapped is handler:
-                return True
-
-            wrapped_id = id(wrapped)
-            if wrapped_id in seen_ids:
-                break
-
-            seen_ids.add(wrapped_id)
-            current = wrapped
-
-        if self._callable_contains_value(candidate, handler):
+    @classmethod
+    def _object_references_value(
+        cls, obj: object, target: object, seen_ids: set[int]
+    ) -> bool:
+        if obj is target:
             return True
 
-        return False
+        obj_id = id(obj)
+        if obj_id in seen_ids:
+            return False
+        seen_ids.add(obj_id)
 
-    @staticmethod
-    def _callable_contains_value(candidate: Callable, value: object) -> bool:
-        """Check common callable storage locations for a captured value."""
-        closure = getattr(candidate, "__closure__", None) or ()
+        wrapped = getattr(obj, "__wrapped__", None)
+        if wrapped is not None and cls._object_references_value(
+            wrapped, target, seen_ids
+        ):
+            return True
+
+        closure = getattr(obj, "__closure__", None) or ()
         for cell in closure:
             try:
-                if cell.cell_contents is value:
+                if cls._object_references_value(cell.cell_contents, target, seen_ids):
                     return True
             except ValueError:
                 continue
 
-        defaults = getattr(candidate, "__defaults__", None) or ()
-        if any(default is value for default in defaults):
-            return True
+        defaults = getattr(obj, "__defaults__", None) or ()
+        for default in defaults:
+            if cls._object_references_value(default, target, seen_ids):
+                return True
 
-        kwdefaults = getattr(candidate, "__kwdefaults__", None) or {}
-        if any(default is value for default in kwdefaults.values()):
-            return True
+        kwdefaults = getattr(obj, "__kwdefaults__", None) or {}
+        for default in kwdefaults.values():
+            if cls._object_references_value(default, target, seen_ids):
+                return True
 
-        candidate_dict = getattr(candidate, "__dict__", None) or {}
-        if any(attr is value for attr in candidate_dict.values()):
-            return True
+        obj_dict = getattr(obj, "__dict__", None) or {}
+        for value in obj_dict.values():
+            if cls._object_references_value(value, target, seen_ids):
+                return True
+
+        if isinstance(obj, dict):
+            for value in obj.values():
+                if cls._object_references_value(value, target, seen_ids):
+                    return True
+        elif isinstance(obj, (list, tuple, set, frozenset)):
+            for value in obj:
+                if cls._object_references_value(value, target, seen_ids):
+                    return True
 
         return False
 

--- a/kinglet/core.py
+++ b/kinglet/core.py
@@ -67,6 +67,29 @@ class Route:
         return self._object_references_value(candidate, handler, set())
 
     @classmethod
+    def _iter_direct_references(cls, obj: object):
+        """Yield directly referenced values commonly used by wrapped callables."""
+        wrapped = getattr(obj, "__wrapped__", None)
+        if wrapped is not None:
+            yield wrapped
+
+        closure = getattr(obj, "__closure__", None) or ()
+        for cell in closure:
+            try:
+                yield cell.cell_contents
+            except ValueError:
+                continue
+
+        yield from getattr(obj, "__defaults__", None) or ()
+        yield from (getattr(obj, "__kwdefaults__", None) or {}).values()
+        yield from (getattr(obj, "__dict__", None) or {}).values()
+
+        if isinstance(obj, dict):
+            yield from obj.values()
+        elif isinstance(obj, (list, tuple, set, frozenset)):
+            yield from obj
+
+    @classmethod
     def _object_references_value(
         cls, obj: object, target: object, seen_ids: set[int]
     ) -> bool:
@@ -78,43 +101,9 @@ class Route:
             return False
         seen_ids.add(obj_id)
 
-        wrapped = getattr(obj, "__wrapped__", None)
-        if wrapped is not None and cls._object_references_value(
-            wrapped, target, seen_ids
-        ):
-            return True
-
-        closure = getattr(obj, "__closure__", None) or ()
-        for cell in closure:
-            try:
-                if cls._object_references_value(cell.cell_contents, target, seen_ids):
-                    return True
-            except ValueError:
-                continue
-
-        defaults = getattr(obj, "__defaults__", None) or ()
-        for default in defaults:
-            if cls._object_references_value(default, target, seen_ids):
-                return True
-
-        kwdefaults = getattr(obj, "__kwdefaults__", None) or {}
-        for default in kwdefaults.values():
-            if cls._object_references_value(default, target, seen_ids):
-                return True
-
-        obj_dict = getattr(obj, "__dict__", None) or {}
-        for value in obj_dict.values():
+        for value in cls._iter_direct_references(obj):
             if cls._object_references_value(value, target, seen_ids):
                 return True
-
-        if isinstance(obj, dict):
-            for value in obj.values():
-                if cls._object_references_value(value, target, seen_ids):
-                    return True
-        elif isinstance(obj, (list, tuple, set, frozenset)):
-            for value in obj:
-                if cls._object_references_value(value, target, seen_ids):
-                    return True
 
         return False
 

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from kinglet import Response
+from kinglet import Kinglet, Response, Router, TestClient
 from kinglet.authz import (
     _b64url_decode,
     _extract_bearer_user,
@@ -220,6 +220,37 @@ class TestGetUser:
             assert result is None
         finally:
             kinglet.authz.verify_jwt_hs256 = original_verify
+
+    def test_require_auth_route_wrong_order_with_include_router(self):
+        """Test wrong-order route decoration still enforces auth after router inclusion."""
+        app = Kinglet()
+        router = Router()
+        secret = "test" + "-secret"
+        token = TestJWTVerification._make_jwt(
+            {"sub": "user-123", "exp": int(time.time()) + 3600}, secret
+        )
+
+        @require_auth
+        @router.get("/profile")
+        async def profile(request):
+            return {"id": request.state.user["id"]}
+        globals()["profile"] = profile
+
+        app.include_router("/api", router)
+        client = TestClient(app, env={"JWT_SECRET": secret})
+
+        status, _, body = client.request("GET", "/api/profile")
+        assert status == 401
+        assert "unauthorized" in body.lower()
+
+        status, _, body = client.request(
+            "GET",
+            "/api/profile",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert status == 200
+        assert "user-123" in body
+        globals().pop("profile", None)
 
 
 class TestD1Resolver:

--- a/tests/test_security_pitfalls.py
+++ b/tests/test_security_pitfalls.py
@@ -138,6 +138,29 @@ class TestDecoratorOrdering:
 class TestRouteResolutionFallbacks:
     """Test route registration and rebinding behavior."""
 
+    def test_resolve_handler_falls_back_without_metadata(self):
+        async def endpoint(request):
+            return {"ok": True}
+
+        route = Router()
+        route.add_route("/fallback", endpoint, ["GET"])
+        registered_route = route.routes[0]
+        registered_route.handler_module = None
+        registered_route.handler_name = None
+
+        assert registered_route.handler is endpoint
+
+    def test_resolve_handler_falls_back_when_module_missing(self):
+        async def endpoint(request):
+            return {"ok": True}
+
+        route = Router()
+        route.add_route("/fallback", endpoint, ["GET"])
+        registered_route = route.routes[0]
+        registered_route.handler_module = "nonexistent.module"
+
+        assert registered_route.handler is endpoint
+
     def test_route_keeps_original_callable_after_same_name_rebind(self):
         router = Router()
 

--- a/tests/test_security_pitfalls.py
+++ b/tests/test_security_pitfalls.py
@@ -239,6 +239,67 @@ class TestRouteResolutionFallbacks:
         assert "secure" in body
         globals().pop("secure_endpoint", None)
 
+    def test_references_handler_detects_default_kwdefault_and_dict_paths(self):
+        router = Router()
+        handler = object()
+
+        def default_wrapper(captured=handler):
+            return captured
+
+        def kwdefault_wrapper(*, captured=handler):
+            return captured
+
+        def dict_wrapper():
+            return handler
+
+        dict_wrapper.marker = {"nested": handler}
+
+        route = router
+        assert route.routes == []
+        route_obj = type("RouteProxy", (), {})()
+        route_obj._references_handler = Router.add_route  # keep linter away
+
+        from kinglet.core import Route
+
+        test_route = Route("/coverage", handler, ["GET"])
+        assert test_route._references_handler(default_wrapper, handler) is True
+        assert test_route._references_handler(kwdefault_wrapper, handler) is True
+        assert test_route._references_handler(dict_wrapper, handler) is True
+
+    def test_references_handler_detects_sequence_path_and_cycle_guard(self):
+        from kinglet.core import Route
+
+        handler = object()
+        test_route = Route("/coverage", handler, ["GET"])
+
+        def sequence_wrapper():
+            return handler
+
+        sequence_wrapper.marker = ["ignore", {"nested": handler}]
+        assert test_route._references_handler(sequence_wrapper, handler) is True
+
+        loop = []
+        loop.append(loop)
+        assert test_route._object_references_value(loop, handler, set()) is False
+
+    def test_references_handler_ignores_empty_closure_cells(self):
+        from kinglet.core import Route
+
+        handler = object()
+        test_route = Route("/coverage", handler, ["GET"])
+
+        def make_empty_cell():
+            captured = object()
+
+            def inner():
+                return captured  # noqa: F821
+
+            del captured
+            return inner
+
+        empty_cell_wrapper = make_empty_cell()
+        assert test_route._references_handler(empty_cell_wrapper, handler) is False
+
 
 class TestResponseVsTupleReturns:
     """Test Response object vs tuple return behavior"""

--- a/tests/test_security_pitfalls.py
+++ b/tests/test_security_pitfalls.py
@@ -10,7 +10,6 @@ import json
 
 import pytest
 
-from kinglet.core import Route
 from kinglet import Kinglet, Response, Router, TestClient, geo_restrict, require_dev
 
 
@@ -137,25 +136,7 @@ class TestDecoratorOrdering:
 
 
 class TestRouteResolutionFallbacks:
-    """Test handler resolution fallbacks for routes."""
-
-    def test_resolve_handler_falls_back_without_metadata(self):
-        async def endpoint(request):
-            return {"ok": True}
-
-        route = Route("/fallback", endpoint, ["GET"])
-        route.handler_module = None
-
-        assert route.handler is endpoint
-
-    def test_resolve_handler_falls_back_when_module_missing(self):
-        async def endpoint(request):
-            return {"ok": True}
-
-        route = Route("/fallback", endpoint, ["GET"])
-        route.handler_module = "nonexistent.module"
-
-        assert route.handler is endpoint
+    """Test route registration and rebinding behavior."""
 
     def test_route_keeps_original_callable_after_same_name_rebind(self):
         router = Router()
@@ -177,44 +158,6 @@ class TestRouteResolutionFallbacks:
         assert params == {}
         assert handler is original_endpoint
         assert handler is not endpoint
-
-    def test_resolve_caches_verified_wrapped_handler(self, monkeypatch):
-        import kinglet.core as core_module
-
-        router = Router()
-
-        @router.get("/admin")
-        async def endpoint(request):
-            return Response({"secret": True}, status=200)
-
-        original_endpoint = endpoint
-        globals()["endpoint"] = endpoint
-
-        calls = {"count": 0}
-        original_references_handler = core_module.Route._references_handler
-
-        def counting_references_handler(self, candidate, handler):
-            calls["count"] += 1
-            return original_references_handler(self, candidate, handler)
-
-        @functools.wraps(endpoint)
-        async def endpoint(request):
-            return await original_endpoint(request)
-
-        globals()["endpoint"] = endpoint
-        monkeypatch.setattr(
-            core_module.Route, "_references_handler", counting_references_handler
-        )
-
-        handler, params = router.resolve("GET", "/admin")
-        assert params == {}
-        assert handler is endpoint
-        assert calls["count"] == 1
-
-        handler, params = router.resolve("GET", "/admin")
-        assert params == {}
-        assert handler is endpoint
-        assert calls["count"] == 1
 
     def test_route_preserves_wrapper_without_functools_wraps(self):
         app = Kinglet()
@@ -246,71 +189,32 @@ class TestRouteResolutionFallbacks:
         assert status == 200
         assert "secret" in body
 
-    def test_references_handler_supports_multiple_wrapper_shapes(self):
-        handler = object()
+    def test_route_rebinds_across_multiple_builtin_wrappers(self):
+        app = Kinglet(auto_wrap_exceptions=False)
 
-        def make_route(candidate_name: str, candidate):
-            route = Route("/coverage", handler, ["GET"])
-            route.handler_module = __name__
-            route.handler_name = candidate_name
-            globals()[candidate_name] = candidate
-            return route
+        @require_dev()
+        @geo_restrict(allowed=["US"])
+        @app.get("/secure")
+        async def secure_endpoint(request):
+            return {"secure": True}
+        globals()["secure_endpoint"] = secure_endpoint
 
-        def module_level_wrapped():
-            return handler
+        client = TestClient(app, env={"ENVIRONMENT": "production"})
 
-        module_level_wrapped.__wrapped__ = handler
-        route = make_route("module_level_wrapped", module_level_wrapped)
-        assert route._references_handler(module_level_wrapped, handler) is True
+        status, _, body = client.request("GET", "/secure", headers={"CF-IPCountry": "US"})
+        assert status == 404
+        assert "Not Found" in body
 
-        def closure_wrapper():
-            captured = handler
+        client = TestClient(app, env={"ENVIRONMENT": "development"})
+        status, _, body = client.request(
+            "GET", "/secure", headers={"CF-IPCountry": "CA"}
+        )
+        assert status == 451
 
-            def wrapped():
-                return captured
-
-            return wrapped
-
-        route = make_route("closure_wrapper", closure_wrapper())
-        assert route._references_handler(closure_wrapper(), handler) is True
-
-        def default_wrapper(captured=handler):
-            return captured
-
-        route = make_route("default_wrapper", default_wrapper)
-        assert route._references_handler(default_wrapper, handler) is True
-
-        def kwdefault_wrapper(*, captured=handler):
-            return captured
-
-        route = make_route("kwdefault_wrapper", kwdefault_wrapper)
-        assert route._references_handler(kwdefault_wrapper, handler) is True
-
-        def dict_wrapper():
-            return handler
-
-        dict_wrapper.marker = handler
-        route = make_route("dict_wrapper", dict_wrapper)
-        assert route._references_handler(dict_wrapper, handler) is True
-
-        class LoopWrapper:
-            def __call__(self):
-                return handler
-
-        loop_wrapper = LoopWrapper()
-        loop_wrapper.__wrapped__ = loop_wrapper
-        route = make_route("loop_wrapper", loop_wrapper)
-        assert route._references_handler(loop_wrapper, handler) is False
-
-        for name in (
-            "module_level_wrapped",
-            "closure_wrapper",
-            "default_wrapper",
-            "kwdefault_wrapper",
-            "dict_wrapper",
-            "loop_wrapper",
-        ):
-            globals().pop(name, None)
+        status, _, body = client.request("GET", "/secure", headers={"CF-IPCountry": "US"})
+        assert status == 200
+        assert "secure" in body
+        globals().pop("secure_endpoint", None)
 
 
 class TestResponseVsTupleReturns:


### PR DESCRIPTION
## What changed
Fixes the route handler security bypasses around decorator ordering and same-name handler resolution.

## Why
Route resolution could swap in the wrong callable or miss nested wrappers, which created auth/access-control bypass paths.

## Validation
- `uv run pytest tests/test_security_pitfalls.py tests/test_decorators.py tests/test_authz.py tests/test_router.py tests/test_app.py tests/test_authz_validation.py tests/test_framework_features.py -q`
- `uv run ruff check kinglet/core.py kinglet/authz.py tests/test_authz.py tests/test_security_pitfalls.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route handler resolution to more robustly support decorated handlers in authorization workflows.
  * Enhanced decorator chain handling to ensure proper metadata preservation in authentication/authorization functions.

* **Tests**
  * Extended test coverage for authorization enforcement and security wrapper integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->