### PR TITLE
Default-deny route security policy (2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,8 +73,20 @@ For each route, do **one** of the following:
 
 - Built-in auth/access decorators (`require_auth`, `require_owner`,
   `require_participant`, `require_claim`, `require_elevated_session`,
-  `require_elevated_claim`, `allow_public_or_owner`, `require_dev`,
-  `geo_restrict`) now mark their routes as secured automatically.
+  `require_elevated_claim`, `allow_public_or_owner`, `require_dev`) now mark
+  their routes as secured automatically.
+- **`geo_restrict` does NOT satisfy the policy.** It reads the forgeable
+  `CF-IPCountry` hint and fails open in production, so it is a supplementary
+  filter, not an identity posture. A geo-restricted route needs `public=True`
+  or a real auth decorator. (`require_dev` fails closed → 404 in production, so
+  it does count.)
+- Disabling the policy (`enforce_route_policy=False`) emits a
+  `RoutePolicyWarning` so an intentional opt-out is not mistaken for one
+  forgotten during migration.
+- `Kinglet` now also exposes `head()` and `options()` route decorators (were
+  previously only on `Router`).
+- The registration error names the offending handler and points at
+  `@security_decorator`.
 - Dispatch is unchanged: a route still executes exactly the callable registered
   at declaration time. No module/global name lookup, closure walking, or
   `__wrapped__` traversal is used to select handlers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,80 @@
+# Changelog
+
+## 2.0.0 — Default-deny route security
+
+### ⚠️ Breaking change: routes must declare their access posture
+
+Kinglet now refuses, by default, to register a route that does not declare how
+it is secured. This closes a class of authorization-bypass findings at the
+framework level: a security decorator applied **above** a route decorator used
+to leave the route silently unprotected (because the route registers and
+dispatches exactly the callable it was given, and the later wrapper is never
+seen). Rather than recover the wrapper by name — which reintroduces route
+confusion — the framework now requires every route to be explicitly public or
+explicitly protected, and fails closed otherwise.
+
+At route registration (import time for module-level routes), a route is accepted
+only if **one** of these holds:
+
+1. It is declared public: `@app.get("/health", public=True)`.
+2. Its handler carries a recognized access-control marker — set by a built-in
+   auth decorator applied with the route decorator outermost, or by a custom
+   decorator wrapped with the new `@security_decorator`.
+
+Otherwise registration raises `RuntimeError` with guidance.
+
+### Migration
+
+For each route, do **one** of the following:
+
+- **Public endpoint** (health, status, docs, public listings):
+  ```python
+  @app.get("/health", public=True)
+  async def health(request): ...
+  ```
+
+- **Protected by a built-in decorator** — no change if already in the correct
+  order (route decorator outermost):
+  ```python
+  @app.get("/admin")
+  @require_auth
+  async def admin(request): ...
+  ```
+
+- **Protected by your own decorator** — wrap it once with `@security_decorator`:
+  ```python
+  from kinglet import security_decorator
+
+  @security_decorator
+  def require_admin(handler):
+      @functools.wraps(handler)
+      async def wrapped(request): ...
+      return wrapped
+  ```
+
+- **Authorize in middleware, or migrate later** — opt out per app:
+  ```python
+  app = Kinglet(enforce_route_policy=False)
+  ```
+
+> `validate_json_body` and `require_field` are validation, not access control;
+> a route carrying only validation still needs `public=True` or real auth.
+
+### Added
+
+- `security_decorator` — make a custom security decorator recognized by the
+  route policy (and fail fast in reversed order).
+- `mark_secured` / `is_secured` — low-level helpers for the access-control marker.
+- `public=True` keyword on all route decorators (`get`/`post`/`put`/`delete`/
+  `patch`/`head`/`options`/`route`) on both `Kinglet` and `Router`.
+- `enforce_route_policy` constructor flag on `Kinglet` and `Router` (default `True`).
+
+### Notes
+
+- Built-in auth/access decorators (`require_auth`, `require_owner`,
+  `require_participant`, `require_claim`, `require_elevated_session`,
+  `require_elevated_claim`, `allow_public_or_owner`, `require_dev`,
+  `geo_restrict`) now mark their routes as secured automatically.
+- Dispatch is unchanged: a route still executes exactly the callable registered
+  at declaration time. No module/global name lookup, closure walking, or
+  `__wrapped__` traversal is used to select handlers.

--- a/CloudFlare-Demo/src/demo_auth.py
+++ b/CloudFlare-Demo/src/demo_auth.py
@@ -2,8 +2,9 @@
 Kinglet Authorization Demo - Simple authentication patterns
 """
 
-from kinglet import Kinglet, Response
-from kinglet.authz import get_user, require_auth
+import kinglet.authz
+from kinglet import Kinglet, Response, security_decorator
+from kinglet.authz import require_auth
 
 app = Kinglet()
 
@@ -15,7 +16,8 @@ async def home(request):
         "endpoints": [
             "/public - No auth required",
             "/protected - Requires authentication",
-            "/admin - Admin access with confirmation",
+            "/manual-auth - Requires authentication (via @require_authenticated decorator)",
+            "/admin/action - Admin access with confirmation (via @require_admin_auth decorator)",
         ],
     }
 
@@ -30,7 +32,7 @@ async def public_endpoint(request):
 @require_auth
 async def protected_endpoint(request):
     """Protected endpoint - requires authentication"""
-    user = await get_user(request)
+    user = await kinglet.authz.get_user(request)
     claims = user.get("claims", {}) if user else {}
     return {
         "message": "You are authenticated",
@@ -39,37 +41,66 @@ async def protected_endpoint(request):
     }
 
 
-# Manual auth check example
-@app.get(
-    "/manual-auth", public=True
-)  # TODO: consider a security decorator — handler does inline auth check
+# ---------------------------------------------------------------------------
+# Custom security decorators — mirror the pattern from secure_admin_example.py.
+# Always call kinglet.authz.get_user through the module so monkeypatching works.
+# ---------------------------------------------------------------------------
+
+
+@security_decorator
+def require_authenticated(handler):
+    """Require a valid authenticated user (JWT). Returns 401 if unauthenticated."""
+
+    async def wrapped(request):
+        user = await kinglet.authz.get_user(request)
+        if not user:
+            return Response({"error": "Authentication required"}, status=401)
+        request.state = getattr(request, "state", type("State", (), {})())
+        request.state.user = user
+        return await handler(request)
+
+    return wrapped
+
+
+@security_decorator
+def require_admin_auth(handler):
+    """Require an authenticated user with role == 'admin'. Returns 401/403 otherwise."""
+
+    async def wrapped(request):
+        user = await kinglet.authz.get_user(request)
+        if not user:
+            return Response({"error": "Authentication required"}, status=401)
+        claims = user.get("claims", {})
+        if claims.get("role") != "admin":
+            return Response({"error": "Admin access required"}, status=403)
+        request.state = getattr(request, "state", type("State", (), {})())
+        request.state.user = user
+        return await handler(request)
+
+    return wrapped
+
+
+# Manual auth check example — now uses a proper @security_decorator wrapper
+@app.get("/manual-auth")
+@require_authenticated  # ← CORRECT: route decorator OUTERMOST, security decorator below
 async def manual_auth_check(request):
-    """Example of manual authentication check"""
-    user = await get_user(request)
-
-    if not user:
-        return Response({"error": "Authentication required"}, status=401)
-
+    """Example of authentication enforced via a custom @security_decorator."""
+    user = request.state.user
     return {
         "message": "Manual auth successful",
         "user": user.get("id"),
-        "method": "manual_check",
+        "method": "security_decorator",
     }
 
 
-# Admin example with proper security
-@app.post(
-    "/admin/action", public=True
-)  # TODO: consider a security decorator — handler does inline role/admin check
+# Admin example with proper security — now uses a proper @security_decorator wrapper
+@app.post("/admin/action")
+@require_admin_auth  # ← CORRECT: route decorator OUTERMOST, security decorator below
 async def admin_action(request):
-    """Admin action with confirmation requirement"""
-    user = await get_user(request)
-    claims = user.get("claims", {}) if user else {}
+    """Admin action with confirmation requirement."""
+    user = request.state.user
+    claims = user.get("claims", {})
     email = claims.get("email", "")
-    role = claims.get("role")
-
-    if not user or role != "admin":
-        return Response({"error": "Admin access required"}, status=403)
 
     # Require confirmation header for dangerous actions
     confirm = request.header("x-confirm-action")

--- a/CloudFlare-Demo/src/demo_auth.py
+++ b/CloudFlare-Demo/src/demo_auth.py
@@ -8,7 +8,7 @@ from kinglet.authz import get_user, require_auth
 app = Kinglet()
 
 
-@app.get("/")
+@app.get("/", public=True)
 async def home(request):
     return {
         "demo": "Kinglet Authorization",
@@ -20,7 +20,7 @@ async def home(request):
     }
 
 
-@app.get("/public")
+@app.get("/public", public=True)
 async def public_endpoint(request):
     """Public endpoint - no auth required"""
     return {"message": "This is public", "auth_required": False}
@@ -40,7 +40,9 @@ async def protected_endpoint(request):
 
 
 # Manual auth check example
-@app.get("/manual-auth")
+@app.get(
+    "/manual-auth", public=True
+)  # TODO: consider a security decorator — handler does inline auth check
 async def manual_auth_check(request):
     """Example of manual authentication check"""
     user = await get_user(request)
@@ -56,7 +58,9 @@ async def manual_auth_check(request):
 
 
 # Admin example with proper security
-@app.post("/admin/action")
+@app.post(
+    "/admin/action", public=True
+)  # TODO: consider a security decorator — handler does inline role/admin check
 async def admin_action(request):
     """Admin action with confirmation requirement"""
     user = await get_user(request)
@@ -86,7 +90,7 @@ async def admin_action(request):
 
 
 # Mock JWT for testing
-@app.post("/mock-login")
+@app.post("/mock-login", public=True)
 async def mock_login(request):
     """Create a mock JWT for testing (demo only)"""
     body = await request.json() or {}

--- a/CloudFlare-Demo/src/demo_media.py
+++ b/CloudFlare-Demo/src/demo_media.py
@@ -1,5 +1,11 @@
 """
 Kinglet Media Demo - R2 storage and binary file handling
+
+# ⚠️ DEMO ONLY — NO AUTHENTICATION on the storage endpoints below.
+# This file demonstrates R2 storage and binary-file handling primitives.
+# Do not copy these routes to production without adding @require_auth (or your
+# own @security_decorator) to any endpoint that reads, writes, or deletes R2
+# objects.
 """
 
 from kinglet import (
@@ -29,6 +35,8 @@ async def home(request):
     }
 
 
+# ⚠️ DEMO ONLY — NO AUTHENTICATION. Do not copy to production. Real deployments
+# must add @require_auth (or your own @security_decorator) before exposing this.
 @app.post("/upload", public=True)
 async def upload_file(request):
     """Upload file to R2 bucket"""
@@ -66,6 +74,8 @@ async def upload_file(request):
         return Response({"error": str(e)}, status=500)
 
 
+# ⚠️ DEMO ONLY — NO AUTHENTICATION. Do not copy to production. Real deployments
+# must add @require_auth (or your own @security_decorator) before exposing this.
 @app.get("/files", public=True)
 async def list_files(request):
     """List files in R2 bucket"""
@@ -103,6 +113,8 @@ async def list_files(request):
         return Response({"error": str(e)}, status=500)
 
 
+# ⚠️ DEMO ONLY — NO AUTHENTICATION. Do not copy to production. Real deployments
+# must add @require_auth (or your own @security_decorator) before exposing this.
 @app.get("/file/{key:path}", public=True)
 async def get_file(request):
     """Get file from R2 bucket"""
@@ -160,6 +172,8 @@ async def get_file(request):
         return Response({"error": str(e)}, status=500)
 
 
+# ⚠️ DEMO ONLY — NO AUTHENTICATION. Do not copy to production. Real deployments
+# must add @require_auth (or your own @security_decorator) before exposing this.
 @app.delete("/delete/{key:path}", public=True)
 async def delete_file(request):
     """Delete file from R2 bucket"""
@@ -190,6 +204,8 @@ async def delete_file(request):
         return Response({"error": str(e)}, status=500)
 
 
+# ⚠️ DEMO ONLY — NO AUTHENTICATION. Do not copy to production. Real deployments
+# must add @require_auth (or your own @security_decorator) before exposing this.
 @app.get("/asset/{asset_type}/{key:path}", public=True)
 async def get_asset_url(request):
     """Generate asset URL for different types"""

--- a/CloudFlare-Demo/src/demo_media.py
+++ b/CloudFlare-Demo/src/demo_media.py
@@ -15,7 +15,7 @@ from kinglet import (
 app = Kinglet()
 
 
-@app.get("/")
+@app.get("/", public=True)
 async def home(request):
     return {
         "demo": "Kinglet Media/R2 Demo",
@@ -29,7 +29,7 @@ async def home(request):
     }
 
 
-@app.post("/upload")
+@app.post("/upload", public=True)
 async def upload_file(request):
     """Upload file to R2 bucket"""
     try:
@@ -66,7 +66,7 @@ async def upload_file(request):
         return Response({"error": str(e)}, status=500)
 
 
-@app.get("/files")
+@app.get("/files", public=True)
 async def list_files(request):
     """List files in R2 bucket"""
     try:
@@ -103,7 +103,7 @@ async def list_files(request):
         return Response({"error": str(e)}, status=500)
 
 
-@app.get("/file/{key:path}")
+@app.get("/file/{key:path}", public=True)
 async def get_file(request):
     """Get file from R2 bucket"""
     key = request.path_params.get("key")
@@ -160,7 +160,7 @@ async def get_file(request):
         return Response({"error": str(e)}, status=500)
 
 
-@app.delete("/delete/{key:path}")
+@app.delete("/delete/{key:path}", public=True)
 async def delete_file(request):
     """Delete file from R2 bucket"""
     key = request.path_params.get("key")
@@ -190,7 +190,7 @@ async def delete_file(request):
         return Response({"error": str(e)}, status=500)
 
 
-@app.get("/asset/{asset_type}/{key:path}")
+@app.get("/asset/{asset_type}/{key:path}", public=True)
 async def get_asset_url(request):
     """Generate asset URL for different types"""
     asset_type = request.path_params.get("asset_type", "media")

--- a/CloudFlare-Demo/src/demo_routing.py
+++ b/CloudFlare-Demo/src/demo_routing.py
@@ -1,5 +1,10 @@
 """
 Kinglet Routing Demo - Basic routing features
+
+# ⚠️ DEMO ONLY — NO AUTHENTICATION on the data endpoints below.
+# This file demonstrates routing primitives (path params, routers, prefixes).
+# Do not copy these routes to production without adding @require_auth (or your
+# own @security_decorator) to any endpoint that returns real user data.
 """
 
 from kinglet import Kinglet, Response, Router
@@ -34,6 +39,8 @@ async def api_status(request):
     return {"status": "ok", "api_version": "v1"}
 
 
+# ⚠️ DEMO ONLY — NO AUTHENTICATION. Do not copy to production. Real deployments
+# must add @require_auth (or your own @security_decorator) before exposing user data.
 @api_router.get("/users", public=True)
 async def list_users(request):
     return {"users": [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]}

--- a/CloudFlare-Demo/src/demo_routing.py
+++ b/CloudFlare-Demo/src/demo_routing.py
@@ -8,18 +8,18 @@ app = Kinglet()
 
 
 # Basic routes
-@app.get("/")
+@app.get("/", public=True)
 async def home(request):
     return {"message": "Kinglet Routing Demo", "version": "2"}
 
 
-@app.get("/hello/{name}")
+@app.get("/hello/{name}", public=True)
 async def hello(request):
     name = request.path_params.get("name", "World")
     return {"greeting": f"Hello, {name}!"}
 
 
-@app.post("/echo")
+@app.post("/echo", public=True)
 async def echo(request):
     body = await request.json() or {}
     return {"echo": body, "method": "POST"}
@@ -29,12 +29,12 @@ async def echo(request):
 api_router = Router()
 
 
-@api_router.get("/status")
+@api_router.get("/status", public=True)
 async def api_status(request):
     return {"status": "ok", "api_version": "v1"}
 
 
-@api_router.get("/users")
+@api_router.get("/users", public=True)
 async def list_users(request):
     return {"users": [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]}
 

--- a/CloudFlare-Demo/src/response_test.py
+++ b/CloudFlare-Demo/src/response_test.py
@@ -7,7 +7,7 @@ from kinglet import Kinglet, Response
 app = Kinglet()
 
 
-@app.get("/")
+@app.get("/", public=True)
 async def home(request):
     return {
         "message": "Response Class Tests",
@@ -22,25 +22,25 @@ async def home(request):
     }
 
 
-@app.get("/text")
+@app.get("/text", public=True)
 async def handle_text_response(request):
     """Test plain text response - what content-type does it get?"""
     return "This is plain text"
 
 
-@app.get("/dict")
+@app.get("/dict", public=True)
 async def handle_dict_response(request):
     """Test dict response - should auto-convert to JSON"""
     return {"type": "dict", "auto_json": True}
 
 
-@app.get("/response-obj")
+@app.get("/response-obj", public=True)
 async def handle_response_object(request):
     """Test explicit Response object"""
     return Response("Explicit response content", status=201)
 
 
-@app.get("/custom-headers")
+@app.get("/custom-headers", public=True)
 async def handle_custom_headers(request):
     """Test Response with custom headers"""
     response = Response({"data": "with headers"}, status=200)
@@ -49,13 +49,13 @@ async def handle_custom_headers(request):
     return response
 
 
-@app.get("/error-static")
+@app.get("/error-static", public=True)
 async def handle_error_static(request):
     """Test Response.error() static method"""
     return Response.error("Something went wrong", 400, request.request_id)
 
 
-@app.get("/content-type")
+@app.get("/content-type", public=True)
 async def handle_content_type(request):
     """Test explicit content-type setting"""
     response = Response("Custom content", status=200)
@@ -63,7 +63,7 @@ async def handle_content_type(request):
     return response
 
 
-@app.get("/json-method")
+@app.get("/json-method", public=True)
 async def handle_json_method(request):
     """Test if Response has json() method"""
     try:

--- a/CloudFlare-Demo/src/worker.py
+++ b/CloudFlare-Demo/src/worker.py
@@ -2,7 +2,7 @@
 Kinglet Demo - Testing all features
 """
 
-from kinglet import Kinglet, Response, Router
+from kinglet import Kinglet, Response, Router, security_decorator
 from kinglet.authz import (
     allow_public_or_owner,
     get_user,
@@ -20,7 +20,7 @@ def _is_local_demo_allowed(request) -> bool:
 
 
 # ============ Basic Routes ============
-@app.get("/")
+@app.get("/", public=True)
 async def hello(request):
     return {
         "message": "Kinglet Demo",
@@ -34,7 +34,7 @@ async def hello(request):
     }
 
 
-@app.get("/health")
+@app.get("/health", public=True)
 async def health_check(request):
     return {"status": "healthy"}
 
@@ -43,7 +43,7 @@ async def health_check(request):
 auth_router = Router()
 
 
-@auth_router.get("/public")
+@auth_router.get("/public", public=True)
 async def public_endpoint(request):
     """Public endpoint - no auth required"""
     return {"message": "This is public", "auth_required": False}
@@ -144,7 +144,7 @@ app.include_router("/totp", totp_router)
 db_router = Router()
 
 
-@db_router.get("/users")
+@db_router.get("/users", public=True)
 async def list_users(request):
     """List users from D1 database"""
     try:
@@ -170,7 +170,7 @@ async def list_users(request):
     }
 
 
-@db_router.post("/users")
+@db_router.post("/users", public=True)
 async def create_user(request):
     """Create user in D1 database"""
     body = await request.json() or {}
@@ -206,7 +206,7 @@ app.include_router("/db", db_router)
 r2_router = Router()
 
 
-@r2_router.get("/files")
+@r2_router.get("/files", public=True)
 async def list_files(request):
     """List files in R2 bucket"""
     try:
@@ -230,7 +230,7 @@ async def list_files(request):
     }
 
 
-@r2_router.get("/file/{key:path}")
+@r2_router.get("/file/{key:path}", public=True)
 async def get_file(request):
     """Get file from R2"""
     key = request.path_params.get("key")
@@ -270,6 +270,7 @@ app.include_router("/r2", r2_router)
 admin_router = Router()
 
 
+@security_decorator
 def require_admin(handler):
     """Admin authentication decorator"""
 
@@ -311,7 +312,9 @@ app.include_router("/admin", admin_router)
 
 
 # ============ SES Email Test ============
-@app.get("/ses/test")
+@app.get(
+    "/ses/test", public=True
+)  # TODO: consider a security decorator — currently guarded only by inline env/demo check
 async def test_ses_signing(request):
     """Test SES SigV4 signing without actually sending email"""
     from kinglet.ses import _sign_aws_request, _get_env_var
@@ -340,10 +343,13 @@ async def test_ses_signing(request):
 
         # Convert JS object to dict for display
         import js
+
         headers_dict = {}
         keys = js.Object.keys(signed_headers).to_py()
         for key in keys:
-            headers_dict[key] = getattr(signed_headers, key, None) or str(js.Reflect.get(signed_headers, key))
+            headers_dict[key] = getattr(signed_headers, key, None) or str(
+                js.Reflect.get(signed_headers, key)
+            )
 
         return {
             "success": True,
@@ -360,7 +366,9 @@ async def test_ses_signing(request):
         }
 
 
-@app.get("/ses/demo")
+@app.get(
+    "/ses/demo", public=True
+)  # TODO: consider a security decorator — currently guarded only by inline _is_local_demo_allowed check
 async def ses_demo_form(request):
     """Simple HTML form for testing email sends - LOCAL ONLY"""
     if not _is_local_demo_allowed(request):
@@ -447,7 +455,9 @@ async def ses_demo_form(request):
     return Response(html, headers={"Content-Type": "text/html"})
 
 
-@app.post("/ses/send")
+@app.post(
+    "/ses/send", public=True
+)  # TODO: consider a security decorator — currently guarded only by inline _is_local_demo_allowed check
 async def send_test_email(request):
     """Actually send a test email via SES"""
     if not _is_local_demo_allowed(request):

--- a/docs/SECURITY_BEST_PRACTICES.md
+++ b/docs/SECURITY_BEST_PRACTICES.md
@@ -39,26 +39,57 @@ async def get_sensitive_data(request):
 3. The route executes exactly the callable it registered — the security wrapper is never called
 4. **Result: Complete authentication bypass**
 
-### Built-in Guardrail (Fail Closed)
+### Default-Deny Route Policy (2.0)
+
 A route executes exactly the callable registered at declaration time. Kinglet never recovers handlers by module/global name lookup or wrapper inspection.
 
-All built-in security and validation decorators (`require_auth`, `require_owner`, `require_participant`, `require_claim`, `require_elevated_session`, `require_elevated_claim`, `allow_public_or_owner`, `require_dev`, `geo_restrict`, `validate_json_body`, `require_field`) detect when they are applied above/outside a route decorator and **raise `RuntimeError` at import time** instead of leaving the route silently unprotected:
+Since **2.0**, route registration is **default-deny**: every route must declare its access posture, or registration raises `RuntimeError` (at import for module-level routes). A route is accepted only if:
+
+1. It is explicitly **public**: `@app.get("/health", public=True)`, or
+2. Its handler carries a recognized **access-control marker** — set by the built-in auth decorators (`require_auth`, `require_owner`, `require_participant`, `require_claim`, `require_elevated_session`, `require_elevated_claim`, `allow_public_or_owner`, `require_dev`, `geo_restrict`) applied with the route decorator **outermost**, or by a custom decorator wrapped with `@security_decorator`.
+
+> Validation decorators (`validate_json_body`, `require_field`) are **not** access control and do not satisfy the policy on their own.
+
+This makes the reversed-order bypass fail closed **by default**, including for custom decorators:
 
 ```python
-@require_auth          # ← RuntimeError at import: cannot protect the route
-@app.get("/secret")
-async def secret(request): ...
+@require_admin          # custom decorator, reversed order
+@app.get("/admin")      # registers a bare handler first ->
+async def admin(request):
+    ...                 # RuntimeError: route has no declared security posture
 ```
 
-Custom security decorators do not get this guardrail automatically. If you write your own, you can opt in:
+```python
+@app.get("/admin")      # correct order
+@require_auth           # built-in marks the route secured -> OK
+async def admin(request): ...
+
+@app.get("/health", public=True)   # explicit public -> OK
+async def health(request): ...
+```
+
+**Making a custom decorator Kinglet-aware** — one line:
 
 ```python
-from kinglet import reject_if_route_registered
+from kinglet import security_decorator
 
+@security_decorator
 def require_admin(handler):
-    reject_if_route_registered(handler, "require_admin")
-    ...
+    @functools.wraps(handler)
+    async def wrapped(request):
+        ...
+    return wrapped
 ```
+
+`@security_decorator` both marks the route as secured *and* makes reversed order fail fast.
+
+**Opting out (staged migration / middleware-based auth).** Apps that authorize in global middleware rather than per-route decorators, or that need to upgrade incrementally, can disable the policy:
+
+```python
+app = Kinglet(enforce_route_policy=False)   # legacy behavior; you own route security
+```
+
+With the policy off, the older guardrail still applies: built-in decorators (and any wrapped with `@security_decorator`) raise if applied above a route decorator. The reversed-order **custom unguarded** decorator bypass is only possible in this opt-out mode.
 
 ### Testing for Decorator Order Issues
 ```python

--- a/docs/SECURITY_BEST_PRACTICES.md
+++ b/docs/SECURITY_BEST_PRACTICES.md
@@ -46,7 +46,9 @@ A route executes exactly the callable registered at declaration time. Kinglet ne
 Since **2.0**, route registration is **default-deny**: every route must declare its access posture, or registration raises `RuntimeError` (at import for module-level routes). A route is accepted only if:
 
 1. It is explicitly **public**: `@app.get("/health", public=True)`, or
-2. Its handler carries a recognized **access-control marker** — set by the built-in auth decorators (`require_auth`, `require_owner`, `require_participant`, `require_claim`, `require_elevated_session`, `require_elevated_claim`, `allow_public_or_owner`, `require_dev`, `geo_restrict`) applied with the route decorator **outermost**, or by a custom decorator wrapped with `@security_decorator`.
+2. Its handler carries a recognized **access-control marker** — set by the built-in auth decorators (`require_auth`, `require_owner`, `require_participant`, `require_claim`, `require_elevated_session`, `require_elevated_claim`, `allow_public_or_owner`, `require_dev`) applied with the route decorator **outermost**, or by a custom decorator wrapped with `@security_decorator`.
+
+> **`geo_restrict` is intentionally NOT a security posture.** Geo-restriction reads `CF-IPCountry`, a forgeable network-layer hint (bypassable via VPN, or by spoofing the header off-Cloudflare), and it fails **open** in production. It is a supplementary filter, not an identity check, so a geo-restricted route still needs `public=True` or a real auth decorator. (Contrast `require_dev`, which fails **closed** — a 404 blackhole in production — and therefore does count as a posture.)
 
 > Validation decorators (`validate_json_body`, `require_field`) are **not** access control and do not satisfy the policy on their own.
 

--- a/examples/basic_api.py
+++ b/examples/basic_api.py
@@ -16,7 +16,7 @@ from kinglet import Kinglet, Response, SchemaGenerator, TestClient
 app = Kinglet(root_path="/api", debug=True)
 
 
-@app.get("/")
+@app.get("/", public=True)
 async def health_check(request):
     """Health check endpoint"""
     import sys
@@ -31,7 +31,7 @@ async def health_check(request):
     }
 
 
-@app.get("/search")
+@app.get("/search", public=True)
 async def search_users(request):
     """Example with typed query parameters"""
     page = request.query_int("page", 1)
@@ -47,7 +47,9 @@ async def search_users(request):
     }
 
 
-@app.get("/users/{user_id}")
+@app.get(
+    "/users/{user_id}", public=True
+)  # TODO: consider a security decorator — handler does inline auth check
 async def get_user(request):
     """Example with typed path parameters and authentication"""
     # Typed path parameter with validation
@@ -65,7 +67,7 @@ async def get_user(request):
     return {"user_id": user_id, "authenticated": True, "token": token}
 
 
-@app.post("/auth/register")
+@app.post("/auth/register", public=True)
 async def register(request):
     """Example with JSON body and validation"""
     data = await request.json()
@@ -87,7 +89,7 @@ async def register(request):
 
 
 # OpenAPI Documentation Endpoints
-@app.get("/openapi.json")
+@app.get("/openapi.json", public=True)
 async def openapi_spec(request):
     """
     OpenAPI 3.0 Specification
@@ -104,7 +106,7 @@ async def openapi_spec(request):
     return Response(generator.generate_spec())
 
 
-@app.get("/docs")
+@app.get("/docs", public=True)
 async def swagger_ui(request):
     """
     Interactive API Documentation (Swagger UI)
@@ -118,7 +120,7 @@ async def swagger_ui(request):
     )
 
 
-@app.get("/redoc")
+@app.get("/redoc", public=True)
 async def redoc_ui(request):
     """
     API Documentation (ReDoc)

--- a/examples/basic_api.py
+++ b/examples/basic_api.py
@@ -10,7 +10,7 @@ import sys
 # Add parent directory to path so we can import kinglet
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from kinglet import Kinglet, Response, SchemaGenerator, TestClient
+from kinglet import Kinglet, Response, SchemaGenerator, TestClient, security_decorator
 
 # Create app with root path for /api endpoints
 app = Kinglet(root_path="/api", debug=True)
@@ -47,24 +47,39 @@ async def search_users(request):
     }
 
 
-@app.get(
-    "/users/{user_id}", public=True
-)  # TODO: consider a security decorator — handler does inline auth check
+@security_decorator
+def require_api_token(handler):
+    """
+    Validates the Bearer token in the Authorization header against the API_TOKEN
+    environment variable.  Demonstrates using @security_decorator for a custom,
+    non-JWT auth scheme.
+    """
+
+    async def wrapped(request):
+        auth_header = request.header("authorization", "")
+        token = (
+            auth_header[7:].strip() if auth_header.lower().startswith("bearer ") else ""
+        )
+        expected_token = os.environ.get("API_TOKEN")
+        if not expected_token or token != expected_token:
+            return Response.error(
+                "Authentication required", status=401, request_id=request.request_id
+            )
+        # Stash validated token on request state for the handler
+        request.state = getattr(request, "state", type("State", (), {})())
+        request.state.token = token
+        return await handler(request)
+
+    return wrapped
+
+
+@app.get("/users/{user_id}")  # ← route decorator OUTERMOST
+@require_api_token  # ← security decorator below
 async def get_user(request):
-    """Example with typed path parameters and authentication"""
+    """Example with typed path parameters and authentication (via @require_api_token)."""
     # Typed path parameter with validation
     user_id = request.path_param_int("user_id")
-
-    # Check authentication by validating the bearer token against a trusted source.
-    auth_header = request.header("authorization", "")
-    token = auth_header[7:].strip() if auth_header.lower().startswith("bearer ") else ""
-    expected_token = os.environ.get("API_TOKEN")
-    if not expected_token or token != expected_token:
-        return Response.error(
-            "Authentication required", status=401, request_id=request.request_id
-        )
-
-    return {"user_id": user_id, "authenticated": True, "token": token}
+    return {"user_id": user_id, "authenticated": True, "token": request.state.token}
 
 
 @app.post("/auth/register", public=True)

--- a/examples/caching_example.py
+++ b/examples/caching_example.py
@@ -28,7 +28,7 @@ set_default_cache_policy(
 
 
 # Example 1: Basic Environment-Aware Caching
-@app.get("/api/basic-data")
+@app.get("/api/basic-data", public=True)
 @cache_aside(cache_type="basic_data", ttl=1800)  # 30 minutes
 async def get_basic_data(request):
     """
@@ -46,7 +46,7 @@ async def get_basic_data(request):
 
 
 # Example 2: Always Cache (Critical Production Data)
-@app.get("/api/critical-data")
+@app.get("/api/critical-data", public=True)
 @cache_aside(
     cache_type="critical_data",
     ttl=3600,  # 1 hour
@@ -66,7 +66,7 @@ async def get_critical_data(request):
 
 
 # Example 3: Never Cache (Sensitive Data)
-@app.get("/api/sensitive-data")
+@app.get("/api/sensitive-data", public=True)
 @cache_aside(
     cache_type="sensitive_data",
     ttl=300,  # TTL ignored due to policy
@@ -95,7 +95,7 @@ class BusinessHoursCachePolicy:
         return 9 <= hour <= 17
 
 
-@app.get("/api/business-reports")
+@app.get("/api/business-reports", public=True)
 @cache_aside(cache_type="business_reports", ttl=1800, policy=BusinessHoursCachePolicy())
 async def get_business_reports(request):
     """
@@ -118,7 +118,7 @@ class FeatureFlagCachePolicy:
         return getattr(request.env, "FEATURE_CACHE_ENABLED", True)
 
 
-@app.get("/api/feature-data")
+@app.get("/api/feature-data", public=True)
 @cache_aside(
     cache_type="feature_data",
     ttl=900,  # 15 minutes
@@ -136,14 +136,14 @@ async def get_feature_data(request):
 
 
 # Example 6: Different TTL for Different Data Types
-@app.get("/api/static-config")
+@app.get("/api/static-config", public=True)
 @cache_aside(cache_type="static_config", ttl=86400)  # 24 hours
 async def get_static_config(request):
     """Long-lived cache for configuration data"""
     return {"config": "rarely_changing_settings", "version": "1.0"}
 
 
-@app.get("/api/live-stats")
+@app.get("/api/live-stats", public=True)
 @cache_aside(cache_type="live_stats", ttl=30)  # 30 seconds
 async def get_live_stats(request):
     """Short-lived cache for frequently changing data"""
@@ -151,7 +151,7 @@ async def get_live_stats(request):
 
 
 # Example 7: Cache with Path Parameters
-@app.get("/api/user/{user_id}/profile")
+@app.get("/api/user/{user_id}/profile", public=True)
 @cache_aside(cache_type="user_profile", ttl=1800)
 async def get_user_profile(request):
     """
@@ -168,7 +168,7 @@ async def get_user_profile(request):
 
 
 # Example 8: Cache with Query Parameters
-@app.get("/api/search")
+@app.get("/api/search", public=True)
 @cache_aside(cache_type="search_results", ttl=600)  # 10 minutes
 async def search_data(request):
     """
@@ -188,7 +188,7 @@ async def search_data(request):
 
 
 # Example 9: Custom Storage Binding
-@app.get("/api/custom-storage")
+@app.get("/api/custom-storage", public=True)
 @cache_aside(
     storage_binding="CUSTOM_CACHE",  # Use different KV namespace
     cache_type="custom_data",
@@ -207,7 +207,7 @@ async def get_custom_storage_data(request):
 
 
 # Example 10: Cache Status Endpoint
-@app.get("/api/cache-status")
+@app.get("/api/cache-status", public=True)
 async def cache_status(request):
     """
     Helper endpoint to check cache configuration.

--- a/examples/d1_cache_example.py
+++ b/examples/d1_cache_example.py
@@ -25,7 +25,7 @@ async def setup_cache(request, handler):
 
 
 # Basic caching with D1 primary strategy
-@app.get("/products")
+@app.get("/products", public=True)
 @cache_aside_d1(cache_type="products", ttl=1800)  # 30 minutes
 async def get_products(request):
     """Get products with D1 caching"""
@@ -58,7 +58,7 @@ async def get_products(request):
 
 
 # Dynamic route caching
-@app.get("/products/{product_id}")
+@app.get("/products/{product_id}", public=True)
 @cache_aside_d1(cache_type="product_detail", ttl=3600)  # 1 hour
 async def get_product_detail(request):
     """Get product details with path-based cache key"""
@@ -78,7 +78,7 @@ async def get_product_detail(request):
 
 
 # Cache management endpoints
-@app.get("/cache/stats")
+@app.get("/cache/stats", public=True)
 async def get_cache_stats(request):
     """Get cache performance statistics"""
     if not hasattr(request.env, "DB"):
@@ -97,7 +97,7 @@ async def get_cache_stats(request):
     }
 
 
-@app.post("/cache/cleanup")
+@app.post("/cache/cleanup", public=True)
 async def cleanup_expired_cache(request):
     """Remove expired cache entries"""
     if not hasattr(request.env, "DB"):
@@ -113,7 +113,7 @@ async def cleanup_expired_cache(request):
     }
 
 
-@app.delete("/cache/invalidate")
+@app.delete("/cache/invalidate", public=True)
 async def invalidate_cache_pattern(request):
     """Invalidate cache entries matching a pattern"""
     body = await request.json() or {}
@@ -140,7 +140,7 @@ async def invalidate_cache_pattern(request):
 from kinglet import AlwaysCachePolicy
 
 
-@app.get("/admin/reports")
+@app.get("/admin/reports", public=True)
 @cache_aside_d1(
     cache_type="admin_reports",
     ttl=300,  # 5 minutes (shorter for admin data)
@@ -163,7 +163,7 @@ async def get_admin_reports(request):
 
 
 # Health check with cache info
-@app.get("/")
+@app.get("/", public=True)
 async def health_check(request):
     """Health check with cache backend info"""
     import sys

--- a/examples/d1_r2_helpers_example.py
+++ b/examples/d1_r2_helpers_example.py
@@ -19,7 +19,7 @@ from kinglet import (
 app = Kinglet()
 
 
-@app.get("/api/games")
+@app.get("/api/games", public=True)
 async def list_games(request):
     """Example using D1 helpers to safely unwrap database results"""
 
@@ -41,7 +41,7 @@ async def list_games(request):
     return {"games": games, "count": len(games)}
 
 
-@app.get("/api/games/{game_id}")
+@app.get("/api/games/{game_id}", public=True)
 async def get_game(request):
     """Example using d1_unwrap for single results"""
     game_id = request.path_param("game_id")
@@ -62,7 +62,7 @@ async def get_game(request):
     return {"game": game}
 
 
-@app.post("/api/media")
+@app.post("/api/media", public=True)
 async def upload_media(request):
     """Example using R2 helpers for file upload"""
 
@@ -103,7 +103,7 @@ async def upload_media(request):
     }
 
 
-@app.get("/api/media/{file_id}")
+@app.get("/api/media/{file_id}", public=True)
 async def get_media(request):
     """Example using R2 helpers for file metadata"""
     file_id = request.path_param("file_id")
@@ -144,7 +144,7 @@ async def get_media(request):
     }
 
 
-@app.delete("/api/media/{file_id}")
+@app.delete("/api/media/{file_id}", public=True)
 async def delete_media(request):
     """Example using R2 delete helper"""
     file_id = request.path_param("file_id")
@@ -155,7 +155,7 @@ async def delete_media(request):
     return {"success": True, "message": f"File {file_id} deleted"}
 
 
-@app.get("/api/media")
+@app.get("/api/media", public=True)
 async def list_media(request):
     """Example using R2 list helper"""
     prefix = request.query("prefix", "")
@@ -168,7 +168,7 @@ async def list_media(request):
     return {"files": result, "prefix": prefix}
 
 
-@app.get("/api/export/games")
+@app.get("/api/export/games", public=True)
 async def export_games(request):
     """Example showing lazy iteration for large datasets"""
 
@@ -201,7 +201,7 @@ async def export_games(request):
     return {"exported_games": len(export_data), "sample": export_data[:5]}
 
 
-@app.get("/api/admin/stats")
+@app.get("/api/admin/stats", public=True)
 async def get_stats(request):
     """Example for small datasets - use list version"""
 

--- a/examples/decorators_example.py
+++ b/examples/decorators_example.py
@@ -81,7 +81,9 @@ async def clear_cache(request):
 # === GEO-RESTRICTED ENDPOINTS ===
 
 
-@app.get("/api/games-us")
+# geo_restrict is a network filter, not auth, so it does not satisfy the route
+# policy on its own - these are public game listings with a regional filter.
+@app.get("/api/games-us", public=True)
 @geo_restrict(allowed=["US"])
 async def us_only_games(request):
     """Games only available in the US"""
@@ -92,7 +94,7 @@ async def us_only_games(request):
     }
 
 
-@app.get("/api/games-global")
+@app.get("/api/games-global", public=True)
 @geo_restrict(blocked=["CN", "RU"])
 async def global_games_with_restrictions(request):
     """Games available globally except in specific countries"""

--- a/examples/decorators_example.py
+++ b/examples/decorators_example.py
@@ -18,7 +18,7 @@ app = Kinglet(debug=True, auto_wrap_exceptions=True)
 # All endpoints automatically get exception wrapping when auto_wrap_exceptions=True
 
 
-@app.get("/api/games")
+@app.get("/api/games", public=True)
 async def get_games(request):
     """Example endpoint that might throw errors - automatically wrapped"""
     # Simulate database access that might fail
@@ -40,7 +40,7 @@ async def get_games(request):
 app_manual = Kinglet(auto_wrap_exceptions=False)
 
 
-@app_manual.get("/api/manual")
+@app_manual.get("/api/manual", public=True)
 @wrap_exceptions(step="manual_endpoint", expose_details=True)
 async def manual_wrapped(request):
     """Manually wrapped endpoint with specific step identifier"""

--- a/examples/experience_api_example.py
+++ b/examples/experience_api_example.py
@@ -55,7 +55,7 @@ app = Kinglet(debug=True, root_path="/api")
 # === EXPERIENCE API WITH CACHING ===
 
 
-@app.get("/homepage")
+@app.get("/homepage", public=True)
 @cache_aside(cache_type="homepage", ttl=3600)  # Cache for 1 hour
 async def get_homepage(request):
     """Homepage Experience API - cached R2 response"""
@@ -77,7 +77,7 @@ async def get_homepage(request):
     }
 
 
-@app.get("/games")
+@app.get("/games", public=True)
 @cache_aside(cache_type="games_list", ttl=1800)  # Cache for 30 minutes
 async def list_games(request):
     """Games list with filtering - cached by query parameters"""
@@ -108,7 +108,7 @@ async def list_games(request):
 # === MEDIA MANAGEMENT ===
 
 
-@app.post("/media")
+@app.post("/media", public=True)
 async def upload_media(request):
     """Upload media and return UID - demonstrates media_url usage"""
     # Simulate file upload
@@ -128,7 +128,7 @@ async def upload_media(request):
     }
 
 
-@app.get("/media/{uid}")
+@app.get("/media/{uid}", public=True)
 async def get_media(request):
     """Get media by UID - demonstrates URL generation"""
     uid = request.path_param("uid")
@@ -144,7 +144,7 @@ async def get_media(request):
 # === GAME DETAIL WITH DYNAMIC PATH CACHING ===
 
 
-@app.get("/games/{slug}")
+@app.get("/games/{slug}", public=True)
 @cache_aside(cache_type="game_detail", ttl=1800)  # Cache each game separately
 async def get_game_detail(request):
     """Game detail page - cached per game slug"""

--- a/examples/middleware_example.py
+++ b/examples/middleware_example.py
@@ -66,9 +66,10 @@ class AuthMiddleware:
         self.exempt_paths = exempt_paths or ["/health", "/public"]
 
     async def process_request(self, request):
+        # Contract: return a Response to short-circuit, or None to continue.
         # Skip auth for exempt paths
         if any(request.path.startswith(path) for path in self.exempt_paths):
-            return request
+            return None
 
         # Check for API key
         api_key = request.header("X-API-Key")
@@ -77,9 +78,9 @@ class AuthMiddleware:
 
             return Response({"error": "API key required"}, status=401)
 
-        # Add user info to request
+        # Add user info to request, then continue to the route
         request.user = {"id": "demo-user", "api_key": api_key}
-        return request
+        return None
 
 
 auth = AuthMiddleware(exempt_paths=["/health", "/public"])

--- a/examples/middleware_example.py
+++ b/examples/middleware_example.py
@@ -87,19 +87,21 @@ app.add_middleware(auth)
 
 
 # Routes to test middleware
-@app.get("/health")
+@app.get("/health", public=True)
 async def health_check(request):
     return {"status": "healthy", "middleware": "working"}
 
 
-@app.get("/api/protected")
+@app.get(
+    "/api/protected", public=True
+)  # TODO: consider a security decorator — auth enforced by AuthMiddleware, not route-level decorator
 async def protected_endpoint(request):
     # This will require X-API-Key header
     user = getattr(request, "user", None)
     return {"message": "Access granted", "user": user}
 
 
-@app.get("/api/data")
+@app.get("/api/data", public=True)
 async def api_data(request):
     # Simulate some processing time to see timing middleware
     import asyncio

--- a/examples/middleware_example.py
+++ b/examples/middleware_example.py
@@ -93,11 +93,16 @@ async def health_check(request):
     return {"status": "healthy", "middleware": "working"}
 
 
-@app.get(
-    "/api/protected", public=True
-)  # TODO: consider a security decorator — auth enforced by AuthMiddleware, not route-level decorator
+# public=True here only satisfies route registration (Kinglet requires every route
+# to declare a posture).  Actual authentication is enforced by AuthMiddleware above,
+# which runs BEFORE the route handler and short-circuits with HTTP 401 when the
+# X-API-Key header is missing or wrong.  This is the correct teaching pattern for
+# app-level middleware auth: the middleware acts as the gate, not the route decorator.
+# In production, prefer a @security_decorator on each route for explicit, per-route
+# security that is visible at a glance rather than relying solely on middleware.
+@app.get("/api/protected", public=True)
 async def protected_endpoint(request):
-    # This will require X-API-Key header
+    # Reaches here only if AuthMiddleware passed the request through.
     user = getattr(request, "user", None)
     return {"message": "Access granted", "user": user}
 

--- a/examples/orm_integration_test/worker.py
+++ b/examples/orm_integration_test/worker.py
@@ -58,7 +58,9 @@ class User(Model):
 
 
 # Migration endpoint (secured with token)
-@app.post("/migrate")
+@app.post(
+    "/migrate", public=True
+)  # TODO: consider a security decorator — handler does inline token auth check
 async def migrate_database(request):
     """Initialize database schema"""
     # Simple security - in production use proper auth
@@ -80,7 +82,7 @@ async def migrate_database(request):
     }
 
 
-@app.get("/schema")
+@app.get("/schema", public=True)
 async def get_schema_sql(request):
     """Get schema SQL for manual setup"""
     models = [Game, User]
@@ -98,7 +100,7 @@ async def get_schema_sql(request):
 
 
 # Demo CRUD endpoints
-@app.post("/games")
+@app.post("/games", public=True)
 async def create_game(request):
     """Create a game - validates fields automatically"""
     try:
@@ -120,7 +122,7 @@ async def create_game(request):
         return {"error": f"Database error: {e}"}, 500
 
 
-@app.get("/games")
+@app.get("/games", public=True)
 async def list_games(request):
     """List games with optional filtering"""
     try:
@@ -158,7 +160,7 @@ async def list_games(request):
         return {"error": f"Query error: {e}"}, 400
 
 
-@app.get("/games/{game_id}")
+@app.get("/games/{game_id}", public=True)
 async def get_game(request):
     """Get specific game"""
     try:
@@ -173,7 +175,7 @@ async def get_game(request):
         return {"error": f"Invalid game ID: {e}"}, 400
 
 
-@app.put("/games/{game_id}")
+@app.put("/games/{game_id}", public=True)
 async def update_game(request):
     """Update game"""
     try:
@@ -196,7 +198,7 @@ async def update_game(request):
         return {"error": f"Validation error: {e}"}, 400
 
 
-@app.delete("/games/{game_id}")
+@app.delete("/games/{game_id}", public=True)
 async def delete_game(request):
     """Delete game"""
     try:
@@ -212,7 +214,7 @@ async def delete_game(request):
         return {"error": f"Invalid game ID: {e}"}, 400
 
 
-@app.post("/users")
+@app.post("/users", public=True)
 async def create_user(request):
     """Create user with uniqueness validation"""
     try:
@@ -235,7 +237,7 @@ async def create_user(request):
         return {"error": f"Validation error: {e}"}, 400
 
 
-@app.get("/users")
+@app.get("/users", public=True)
 async def list_users(request):
     """List users"""
     try:
@@ -252,7 +254,7 @@ async def list_users(request):
         return {"error": str(e)}, 500
 
 
-@app.get("/stats")
+@app.get("/stats", public=True)
 async def get_stats(request):
     """Get database statistics - demonstrates count queries"""
     try:
@@ -277,7 +279,7 @@ async def get_stats(request):
 
 
 # Demo data endpoints
-@app.post("/demo/seed")
+@app.post("/demo/seed", public=True)
 async def seed_demo_data(request):
     """Seed database with demo data - demonstrates bulk operations"""
     try:
@@ -387,7 +389,7 @@ async def seed_demo_data(request):
         return {"error": str(e)}, 500
 
 
-@app.get("/demo/test-queries")
+@app.get("/demo/test-queries", public=True)
 async def test_queries(request):
     """Demonstrate various query capabilities and D1 optimizations"""
     try:
@@ -421,7 +423,7 @@ async def test_queries(request):
         return {"error": str(e)}, 500
 
 
-@app.post("/demo/bulk-update")
+@app.post("/demo/bulk-update", public=True)
 async def demo_bulk_update(request):
     """Demonstrate bulk update operations"""
     try:
@@ -442,7 +444,7 @@ async def demo_bulk_update(request):
         return {"error": str(e)}, 500
 
 
-@app.post("/demo/bulk-delete")
+@app.post("/demo/bulk-delete", public=True)
 async def demo_bulk_delete(request):
     """Demonstrate bulk delete operations"""
     try:
@@ -461,7 +463,7 @@ async def demo_bulk_delete(request):
 
 
 # Health check endpoint
-@app.get("/")
+@app.get("/", public=True)
 async def health_check(request):
     """Health check and API info"""
     return {

--- a/examples/r2_media_example.py
+++ b/examples/r2_media_example.py
@@ -23,7 +23,7 @@ app = Kinglet()
 router = Router()
 
 
-@router.post("/media")
+@router.post("/media", public=True)
 async def upload_media(request):
     """Upload binary content to R2"""
     import uuid
@@ -48,7 +48,7 @@ async def upload_media(request):
     return {"error": "No binary data provided"}
 
 
-@router.get("/media/{media_id}")
+@router.get("/media/{media_id}", public=True)
 async def get_media(request):
     """Serve binary content from R2 - The key technique"""
     media_id = request.path_param("media_id")

--- a/examples/secure_admin_example.py
+++ b/examples/secure_admin_example.py
@@ -11,8 +11,8 @@ Demonstrates proper security patterns for admin endpoints including:
 This example reflects lessons learned from real-world security issues.
 """
 
+import kinglet.authz
 from kinglet import Kinglet, Response, Router, security_decorator
-from kinglet.authz import get_user
 
 app = Kinglet(debug=False)  # Production security settings
 admin_router = Router()
@@ -34,8 +34,10 @@ def require_admin(handler):
     """
 
     async def wrapped(request):
-        # Layer 1: Require authentication
-        user = await get_user(request)
+        # Layer 1: Require authentication. Call through the module
+        # (kinglet.authz.get_user) rather than a directly-imported name so that
+        # tests/tools that monkeypatch kinglet.authz.get_user take effect.
+        user = await kinglet.authz.get_user(request)
         if not user:
             return Response(
                 {

--- a/examples/secure_admin_example.py
+++ b/examples/secure_admin_example.py
@@ -11,7 +11,7 @@ Demonstrates proper security patterns for admin endpoints including:
 This example reflects lessons learned from real-world security issues.
 """
 
-from kinglet import Kinglet, Response, Router
+from kinglet import Kinglet, Response, Router, security_decorator
 from kinglet.authz import get_user
 
 app = Kinglet(debug=False)  # Production security settings
@@ -22,6 +22,7 @@ admin_router = Router()
 # ============================================================================
 
 
+@security_decorator
 def require_admin(handler):
     """
     Multi-layer admin security decorator
@@ -276,7 +277,7 @@ async def get_cache_info(request):
 # ============================================================================
 
 
-@app.get("/health")
+@app.get("/health", public=True)
 async def health_check(request):
     """Public health check endpoint - no authentication required"""
     return {
@@ -287,7 +288,7 @@ async def health_check(request):
     }
 
 
-@app.get("/api/games")
+@app.get("/api/games", public=True)
 async def list_games(request):
     """Public games list - no authentication required"""
     return {

--- a/examples/ses_email_example.py
+++ b/examples/ses_email_example.py
@@ -27,7 +27,7 @@ from kinglet import Kinglet, Response
 app = Kinglet()
 
 
-@app.post("/send-email")
+@app.post("/send-email", public=True)
 async def send_email_endpoint(request):
     """
     Send an email via SES
@@ -67,7 +67,7 @@ async def send_email_endpoint(request):
         return Response.error(result.error or "Failed to send email", status=500)
 
 
-@app.post("/notify")
+@app.post("/notify", public=True)
 async def send_notification(request):
     """
     Example: Send notification email with template

--- a/examples/totp_example.py
+++ b/examples/totp_example.py
@@ -339,12 +339,13 @@ async def admin_disable_totp(request):
 # ============================================
 
 
-@app.get("/auth/totp/test-info")
+@app.get("/auth/totp/test-info", public=True)
 async def get_test_info(request):
     """
     Development endpoint showing TOTP configuration
     Only available when TOTP_ENABLED=false
     """
+    # TODO: consider a security decorator if this should be restricted beyond the inline TOTP_ENABLED check
     totp_enabled = getattr(request.env, "TOTP_ENABLED", "true").lower() == "true"
 
     if totp_enabled:

--- a/examples/totp_workers_demo/worker.py
+++ b/examples/totp_workers_demo/worker.py
@@ -20,6 +20,7 @@ from kinglet.totp import (
 try:
     from workers import WorkerEntrypoint
 except ModuleNotFoundError:
+
     class WorkerEntrypoint:
         def __init__(self, ctx=None, env=None):
             self.ctx = ctx
@@ -41,12 +42,12 @@ class Default(WorkerEntrypoint):
         return await app(request, self.env)
 
 
-@app.get("/")
+@app.get("/", public=True)
 async def health(request):
     return {"status": "healthy", "demo": "kinglet-totp-workers-demo"}
 
 
-@app.get("/auth/totp/test-info")
+@app.get("/auth/totp/test-info", public=True)
 async def test_info(request):
     return {
         "environment": _env_get(request.env, "ENVIRONMENT", "unknown"),

--- a/kinglet/__init__.py
+++ b/kinglet/__init__.py
@@ -12,6 +12,7 @@ from .core import Kinglet, Route, Router
 
 # Decorators
 from .decorators import (
+    RoutePolicyWarning,
     geo_restrict,
     is_route_registered,
     is_secured,
@@ -260,6 +261,7 @@ __all__ = [
     "security_decorator",
     "mark_secured",
     "is_secured",
+    "RoutePolicyWarning",
     # Utilities
     "CacheService",
     "cache_aside",

--- a/kinglet/__init__.py
+++ b/kinglet/__init__.py
@@ -14,9 +14,12 @@ from .core import Kinglet, Route, Router
 from .decorators import (
     geo_restrict,
     is_route_registered,
+    is_secured,
+    mark_secured,
     reject_if_route_registered,
     require_dev,
     require_field,
+    security_decorator,
     validate_json_body,
     wrap_exceptions,
 )
@@ -181,7 +184,7 @@ try:
 except ImportError:
     _openapi_available = False
 
-__version__ = "1.9.0"
+__version__ = "2.0.0"
 __author__ = "Mitchell Currie"
 
 
@@ -254,6 +257,9 @@ __all__ = [
     "require_field",
     "is_route_registered",
     "reject_if_route_registered",
+    "security_decorator",
+    "mark_secured",
+    "is_secured",
     # Utilities
     "CacheService",
     "cache_aside",

--- a/kinglet/authz.py
+++ b/kinglet/authz.py
@@ -11,7 +11,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from .constants import AUTH_REQUIRED, NOT_FOUND, TOTP_STEP_UP_PATH
-from .decorators import reject_if_route_registered
+from .decorators import mark_secured, reject_if_route_registered
 from .http import Response  # Import directly from http module
 
 
@@ -174,7 +174,7 @@ def require_auth(handler: Callable[[Any], Awaitable[Any]]):
         req.state.user = user
         return await handler(req)
 
-    return wrapped
+    return mark_secured(wrapped)
 
 
 def allow_public_or_owner(
@@ -208,7 +208,7 @@ def allow_public_or_owner(
                 return Response({"error": NOT_FOUND}, status=404)
             return Response({"error": "forbidden"}, status=403)
 
-        return wrapped
+        return mark_secured(wrapped)
 
     return deco
 
@@ -242,7 +242,7 @@ def require_owner(
                 return await handler(req, obj=rec)
             return Response({"error": "forbidden"}, status=403)
 
-        return wrapped
+        return mark_secured(wrapped)
 
     return deco
 
@@ -273,7 +273,7 @@ def require_participant(
                 return await handler(req)
             return Response({"error": "forbidden"}, status=403)
 
-        return wrapped
+        return mark_secured(wrapped)
 
     return deco
 
@@ -329,7 +329,7 @@ def require_elevated_session(handler: Callable[[Any], Awaitable[Any]]):
         req.state.user = user
         return await handler(req)
 
-    return wrapped
+    return mark_secured(wrapped)
 
 
 def require_claim(claim_name: str, claim_value: Any = True):
@@ -362,7 +362,7 @@ def require_claim(claim_name: str, claim_value: Any = True):
             req.state.user = user
             return await handler(req)
 
-        return wrapped
+        return mark_secured(wrapped)
 
     return deco
 
@@ -412,7 +412,7 @@ def require_elevated_claim(claim_name: str, claim_value: Any = True):
             req.state.user = user
             return await handler(req)
 
-        return wrapped
+        return mark_secured(wrapped)
 
     return deco
 

--- a/kinglet/core.py
+++ b/kinglet/core.py
@@ -5,9 +5,14 @@ Kinglet Core - Routing and application framework
 from __future__ import annotations
 
 import re
+import warnings
 from collections.abc import Callable
 
-from .decorators import assert_route_security, mark_route_registered
+from .decorators import (
+    RoutePolicyWarning,
+    assert_route_security,
+    mark_route_registered,
+)
 from .exceptions import HTTPError
 from .http import Request, Response
 from .middleware import Middleware
@@ -97,6 +102,15 @@ class Router:
         # recognized access-control marker. Opt out for staged migration or
         # middleware-based authorization.
         self.enforce_route_policy = enforce_route_policy
+        if not enforce_route_policy:
+            warnings.warn(
+                "Route security policy is disabled (enforce_route_policy=False): "
+                "routes may register without declaring a security posture. This "
+                "removes a guard against accidentally unprotected routes - ensure "
+                "authorization is enforced elsewhere (e.g. middleware).",
+                RoutePolicyWarning,
+                stacklevel=2,
+            )
 
     def add_route(
         self, path: str, handler: Callable, methods: list[str], public: bool = False
@@ -231,6 +245,14 @@ class Kinglet:
     def patch(self, path: str, *, public: bool = False):
         """PATCH route decorator"""
         return self.route(path, ["PATCH"], public=public)
+
+    def head(self, path: str, *, public: bool = False):
+        """HEAD route decorator"""
+        return self.route(path, ["HEAD"], public=public)
+
+    def options(self, path: str, *, public: bool = False):
+        """OPTIONS route decorator"""
+        return self.route(path, ["OPTIONS"], public=public)
 
     def include_router(self, prefix: str, router: Router):
         """Include a sub-router with path prefix"""

--- a/kinglet/core.py
+++ b/kinglet/core.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import re
 from collections.abc import Callable
 
-from .decorators import mark_route_registered
+from .decorators import assert_route_security, mark_route_registered
 from .exceptions import HTTPError
 from .http import Request, Response
 from .middleware import Middleware
@@ -23,10 +23,13 @@ class Route:
     decorators raise at import time if applied in the wrong order.
     """
 
-    def __init__(self, path: str, handler: Callable, methods: list[str]):
+    def __init__(
+        self, path: str, handler: Callable, methods: list[str], public: bool = False
+    ):
         self.path = path
         self.handler = mark_route_registered(handler)
         self.methods = [m.upper() for m in methods]
+        self.public = public  # explicit access posture, preserved for include_router
 
         # Convert path to regex with parameter extraction
         self.regex, self.param_names = self._compile_path(path)
@@ -87,53 +90,61 @@ class Route:
 class Router:
     """HTTP router for organizing routes"""
 
-    def __init__(self):
+    def __init__(self, enforce_route_policy: bool = True):
         self.routes: list[Route] = []
         self.sub_routers: list[Router] = []
+        # Default-deny: every route must be explicitly public or carry a
+        # recognized access-control marker. Opt out for staged migration or
+        # middleware-based authorization.
+        self.enforce_route_policy = enforce_route_policy
 
-    def add_route(self, path: str, handler: Callable, methods: list[str]):
+    def add_route(
+        self, path: str, handler: Callable, methods: list[str], public: bool = False
+    ):
         """Add a route to the router"""
-        route = Route(path, handler, methods)
+        if self.enforce_route_policy:
+            assert_route_security(handler, public=public, path=path)
+        route = Route(path, handler, methods, public=public)
         self.routes.append(route)
 
-    def route(self, path: str, methods: list[str] = None):
+    def route(self, path: str, methods: list[str] = None, *, public: bool = False):
         """Decorator for adding routes"""
         if methods is None:
             methods = ["GET"]
 
         def decorator(handler):
-            self.add_route(path, handler, methods)
+            self.add_route(path, handler, methods, public=public)
             return handler
 
         return decorator
 
-    def get(self, path: str):
+    def get(self, path: str, *, public: bool = False):
         """Decorator for GET routes"""
-        return self.route(path, ["GET"])
+        return self.route(path, ["GET"], public=public)
 
-    def post(self, path: str):
+    def post(self, path: str, *, public: bool = False):
         """Decorator for POST routes"""
-        return self.route(path, ["POST"])
+        return self.route(path, ["POST"], public=public)
 
-    def put(self, path: str):
+    def put(self, path: str, *, public: bool = False):
         """Decorator for PUT routes"""
-        return self.route(path, ["PUT"])
+        return self.route(path, ["PUT"], public=public)
 
-    def delete(self, path: str):
+    def delete(self, path: str, *, public: bool = False):
         """Decorator for DELETE routes"""
-        return self.route(path, ["DELETE"])
+        return self.route(path, ["DELETE"], public=public)
 
-    def patch(self, path: str):
+    def patch(self, path: str, *, public: bool = False):
         """Decorator for PATCH routes"""
-        return self.route(path, ["PATCH"])
+        return self.route(path, ["PATCH"], public=public)
 
-    def head(self, path: str):
+    def head(self, path: str, *, public: bool = False):
         """Decorator for HEAD routes"""
-        return self.route(path, ["HEAD"])
+        return self.route(path, ["HEAD"], public=public)
 
-    def options(self, path: str):
+    def options(self, path: str, *, public: bool = False):
         """Decorator for OPTIONS routes"""
-        return self.route(path, ["OPTIONS"])
+        return self.route(path, ["OPTIONS"], public=public)
 
     def include_router(self, prefix: str, router: Router):
         """Include another router with a path prefix"""
@@ -143,9 +154,11 @@ class Router:
         prefix = prefix.rstrip("/")
 
         for route in router.routes:
-            # Combine prefix with route path
+            # Combine prefix with route path. Routes were already validated at
+            # their own registration; propagate their declared public posture
+            # so the merge does not re-reject intentionally public routes.
             new_path = prefix + route.path
-            self.add_route(new_path, route.handler, route.methods)
+            self.add_route(new_path, route.handler, route.methods, public=route.public)
 
     def resolve(self, method: str, path: str) -> tuple[Callable | None, dict[str, str]]:
         """Find matching route and return handler with path params"""
@@ -164,50 +177,60 @@ class Kinglet:
     """Main application class"""
 
     def __init__(
-        self, test_mode=False, root_path="", debug=False, auto_wrap_exceptions=True
+        self,
+        test_mode=False,
+        root_path="",
+        debug=False,
+        auto_wrap_exceptions=True,
+        enforce_route_policy=True,
     ):
-        self.router = Router()
+        self.router = Router(enforce_route_policy=enforce_route_policy)
         self.middleware_stack: list[Middleware] = []
         self.error_handlers: dict[int, Callable] = {}
         self.test_mode = test_mode
         self.root_path = root_path.rstrip("/")  # Remove trailing slash
         self.debug = debug
         self.auto_wrap_exceptions = auto_wrap_exceptions
+        self.enforce_route_policy = enforce_route_policy
 
-    def route(self, path: str, methods: list[str] = None):
+    def route(self, path: str, methods: list[str] = None, *, public: bool = False):
         """Add route decorator"""
 
         def decorator(handler):
-            # Auto-wrap with exception handling if enabled
+            # Auto-wrap with exception handling if enabled. functools.wraps in
+            # wrap_exceptions preserves any access-control marker on the inner
+            # handler, so the policy check below still sees it.
             if self.auto_wrap_exceptions:
                 from .decorators import wrap_exceptions
 
                 handler = wrap_exceptions(expose_details=self.debug)(handler)
 
-            self.router.add_route(self.root_path + path, handler, methods or ["GET"])
+            self.router.add_route(
+                self.root_path + path, handler, methods or ["GET"], public=public
+            )
             return handler
 
         return decorator
 
-    def get(self, path: str):
+    def get(self, path: str, *, public: bool = False):
         """GET route decorator"""
-        return self.route(path, ["GET"])
+        return self.route(path, ["GET"], public=public)
 
-    def post(self, path: str):
+    def post(self, path: str, *, public: bool = False):
         """POST route decorator"""
-        return self.route(path, ["POST"])
+        return self.route(path, ["POST"], public=public)
 
-    def put(self, path: str):
+    def put(self, path: str, *, public: bool = False):
         """PUT route decorator"""
-        return self.route(path, ["PUT"])
+        return self.route(path, ["PUT"], public=public)
 
-    def delete(self, path: str):
+    def delete(self, path: str, *, public: bool = False):
         """DELETE route decorator"""
-        return self.route(path, ["DELETE"])
+        return self.route(path, ["DELETE"], public=public)
 
-    def patch(self, path: str):
+    def patch(self, path: str, *, public: bool = False):
         """PATCH route decorator"""
-        return self.route(path, ["PATCH"])
+        return self.route(path, ["PATCH"], public=public)
 
     def include_router(self, prefix: str, router: Router):
         """Include a sub-router with path prefix"""

--- a/kinglet/core.py
+++ b/kinglet/core.py
@@ -161,7 +161,14 @@ class Router:
         return self.route(path, ["OPTIONS"], public=public)
 
     def include_router(self, prefix: str, router: Router):
-        """Include another router with a path prefix"""
+        """Include another router with a path prefix.
+
+        Routes are re-validated against *this* router's policy as they are
+        merged (strict wins), so a sub-router built with
+        ``enforce_route_policy=False`` must still declare each route
+        ``public=True`` or secured before it can be included into an enforcing
+        parent - otherwise ``include_router`` raises ``RuntimeError``.
+        """
         # Normalize prefix: ensure it starts with / and doesn't end with /
         if not prefix.startswith("/"):
             prefix = "/" + prefix
@@ -255,7 +262,13 @@ class Kinglet:
         return self.route(path, ["OPTIONS"], public=public)
 
     def include_router(self, prefix: str, router: Router):
-        """Include a sub-router with path prefix"""
+        """Include a sub-router with path prefix.
+
+        Routes are re-validated against the app's policy as they are merged, so
+        a sub-router built with ``enforce_route_policy=False`` must still declare
+        each route ``public=True`` or secured before it can be included into an
+        enforcing app - otherwise this raises ``RuntimeError``.
+        """
         self.router.include_router(self.root_path + prefix, router)
 
     def exception_handler(self, status_code: int):

--- a/kinglet/decorators.py
+++ b/kinglet/decorators.py
@@ -66,6 +66,106 @@ def reject_if_route_registered(handler: Callable, decorator_name: str) -> None:
         )
 
 
+# ---------------------------------------------------------------------------
+# Route security policy: default-deny route registration
+#
+# Under enforce_route_policy (default in 2.0), a route may only be registered
+# if it is explicitly declared public (``public=True``) or its handler carries
+# a recognized access-control marker. This makes the reversed-order custom
+# decorator bypass fail closed *by default*, without any module/global name
+# lookup: at registration time the handler is simply inspected for the marker.
+# ---------------------------------------------------------------------------
+
+# Set on the wrapper produced by a recognized access-control decorator. Stored
+# as a normal function attribute so it lives in ``__dict__`` and therefore
+# propagates outward through ``functools.wraps`` when decorators are stacked.
+SECURED_ATTR = "__kinglet_secured__"
+
+# Fallback registry for secured callables that cannot carry attributes.
+_UNMARKABLE_SECURED_HANDLERS: weakref.WeakSet = weakref.WeakSet()
+
+
+def mark_secured(handler: Callable) -> Callable:
+    """Mark a callable as carrying an access-control posture.
+
+    Recognized built-in access decorators call this on their wrapper, and
+    :func:`security_decorator` calls it for custom decorators. The route
+    policy then accepts the route without requiring ``public=True``.
+    """
+    try:
+        setattr(handler, SECURED_ATTR, True)
+    except (AttributeError, TypeError):
+        with contextlib.suppress(TypeError):
+            _UNMARKABLE_SECURED_HANDLERS.add(handler)
+    return handler
+
+
+def is_secured(handler: Callable) -> bool:
+    """Return True if the callable carries a recognized access-control marker."""
+    if getattr(handler, SECURED_ATTR, False):
+        return True
+    try:
+        return handler in _UNMARKABLE_SECURED_HANDLERS
+    except TypeError:
+        return False
+
+
+def security_decorator(decorator_fn: Callable) -> Callable:
+    """Make a custom security decorator Kinglet-aware.
+
+    Wrap your own access-control decorator so its output is recognized by the
+    default-deny route policy and so applying it in reversed order fails fast::
+
+        @security_decorator
+        def require_admin(handler):
+            @functools.wraps(handler)
+            async def wrapped(request):
+                ...
+            return wrapped
+
+        @app.get("/admin")   # correct order: enforced
+        @require_admin
+        async def admin(request): ...
+
+        @require_admin        # reversed order: RuntimeError at import
+        @app.get("/admin")
+        async def admin(request): ...
+    """
+
+    @functools.wraps(decorator_fn)
+    def aware_decorator(handler: Callable) -> Callable:
+        reject_if_route_registered(
+            handler, getattr(decorator_fn, "__name__", "decorator")
+        )
+        wrapped = decorator_fn(handler)
+        return mark_secured(wrapped)
+
+    return aware_decorator
+
+
+def assert_route_security(handler: Callable, *, public: bool, path: str = "") -> None:
+    """Fail closed if a route is neither explicitly public nor secured.
+
+    Called at route registration. Deterministic: it only inspects the handler
+    that will actually be dispatched - no module scanning, name lookup, or
+    closure inspection.
+    """
+    if public or is_secured(handler):
+        return
+    where = f" for {path!r}" if path else ""
+    raise RuntimeError(
+        f"Route{where} has no declared security posture. Under the default "
+        f"route policy every route must be explicitly public or protected by "
+        f"a recognized access-control decorator.\n\n"
+        f"  - Public endpoint:    @app.get('/path', public=True)\n"
+        f"  - Built-in auth:      @app.get('/path')\n"
+        f"                        @require_auth   # (route decorator outermost)\n"
+        f"  - Custom decorator:   wrap it with @security_decorator so Kinglet\n"
+        f"                        recognizes it as access control.\n\n"
+        f"To opt out during migration: Kinglet(enforce_route_policy=False)."
+    )
+
+
 def wrap_exceptions(step: str = None, expose_details: bool = None):
     """
     Decorator to automatically wrap exceptions in standardized error responses.
@@ -137,7 +237,7 @@ def require_dev():
 
             return await handler(request)
 
-        return wrapped
+        return mark_secured(wrapped)
 
     return decorator
 
@@ -175,7 +275,7 @@ def geo_restrict(*, allowed: list = None, blocked: list = None):
 
             return await handler(request)
 
-        return wrapped
+        return mark_secured(wrapped)
 
     return decorator
 

--- a/kinglet/decorators.py
+++ b/kinglet/decorators.py
@@ -121,16 +121,16 @@ def is_secured(handler: Callable) -> bool:
 
 
 def security_decorator(decorator_fn: Callable) -> Callable:
-    """Make a custom security decorator Kinglet-aware.
+    """Make a custom *simple* security decorator Kinglet-aware.
 
-    Wrap your own access-control decorator so its output is recognized by the
-    default-deny route policy and so applying it in reversed order fails fast::
+    A simple decorator has the shape ``def deco(handler) -> wrapped``. Wrapping
+    it with ``@security_decorator`` makes its output satisfy the default-deny
+    route policy and makes reversed decorator order fail fast::
 
         @security_decorator
         def require_admin(handler):
             @functools.wraps(handler)
-            async def wrapped(request):
-                ...
+            async def wrapped(request): ...
             return wrapped
 
         @app.get("/admin")   # correct order: enforced
@@ -140,10 +140,40 @@ def security_decorator(decorator_fn: Callable) -> Callable:
         @require_admin        # reversed order: RuntimeError at import
         @app.get("/admin")
         async def admin(request): ...
+
+    **Parameterized factories** (``def require_role(role) -> deco -> wrapped``)
+    take an argument, so they are NOT simple decorators. Apply
+    ``@security_decorator`` to the *inner* decorator the factory returns, not to
+    the factory itself::
+
+        def require_role(role):
+            @security_decorator
+            def deco(handler):
+                @functools.wraps(handler)
+                async def wrapped(request): ...
+                return wrapped
+            return deco
+
+        @app.get("/admin")
+        @require_role("admin")   # works: the inner deco is the secured one
+        async def admin(request): ...
+
+    Applying ``@security_decorator`` directly to a factory is rejected at call
+    time with a ``TypeError`` (rather than silently mis-marking the factory
+    instead of the handler, which would leave the route unprotected).
     """
 
     @functools.wraps(decorator_fn)
     def aware_decorator(handler: Callable) -> Callable:
+        if not callable(handler):
+            raise TypeError(
+                f"@security_decorator expects a simple decorator "
+                f"`def {getattr(decorator_fn, '__name__', 'deco')}(handler): ...`, "
+                f"but it was invoked with a non-callable argument {handler!r}. "
+                f"This usually means it was applied to a decorator FACTORY "
+                f"(e.g. require_role('admin')). Apply @security_decorator to the "
+                f"INNER decorator the factory returns instead - see its docstring."
+            )
         reject_if_route_registered(
             handler, getattr(decorator_fn, "__name__", "decorator")
         )

--- a/kinglet/decorators.py
+++ b/kinglet/decorators.py
@@ -76,6 +76,16 @@ def reject_if_route_registered(handler: Callable, decorator_name: str) -> None:
 # lookup: at registration time the handler is simply inspected for the marker.
 # ---------------------------------------------------------------------------
 
+
+class RoutePolicyWarning(UserWarning):
+    """Emitted when the default-deny route policy is disabled.
+
+    Disabling enforcement removes a framework-level guard against accidentally
+    unprotected routes; the warning leaves an audit signal so an intentional
+    opt-out is not mistaken for one forgotten during migration.
+    """
+
+
 # Set on the wrapper produced by a recognized access-control decorator. Stored
 # as a normal function attribute so it lives in ``__dict__`` and therefore
 # propagates outward through ``functools.wraps`` when decorators are stacked.
@@ -153,15 +163,20 @@ def assert_route_security(handler: Callable, *, public: bool, path: str = "") ->
     if public or is_secured(handler):
         return
     where = f" for {path!r}" if path else ""
+    name = getattr(handler, "__name__", None) or repr(handler)
     raise RuntimeError(
-        f"Route{where} has no declared security posture. Under the default "
-        f"route policy every route must be explicitly public or protected by "
-        f"a recognized access-control decorator.\n\n"
+        f"Route{where} (handler {name!r}) has no declared security posture. "
+        f"Under the default route policy every route must be explicitly public "
+        f"or protected by a recognized access-control decorator. If {name!r} is "
+        f"protected by a custom decorator, that decorator must be wrapped with "
+        f"@security_decorator to be recognized.\n\n"
         f"  - Public endpoint:    @app.get('/path', public=True)\n"
         f"  - Built-in auth:      @app.get('/path')\n"
         f"                        @require_auth   # (route decorator outermost)\n"
         f"  - Custom decorator:   wrap it with @security_decorator so Kinglet\n"
         f"                        recognizes it as access control.\n\n"
+        f"Note: geo_restrict is a network filter, not an identity check - a\n"
+        f"geo-restricted route still needs public=True or a real auth decorator.\n\n"
         f"To opt out during migration: Kinglet(enforce_route_policy=False)."
     )
 
@@ -275,7 +290,14 @@ def geo_restrict(*, allowed: list = None, blocked: list = None):
 
             return await handler(request)
 
-        return mark_secured(wrapped)
+        # Deliberately NOT mark_secured: geo-restriction is a forgeable
+        # network-layer hint (CF-IPCountry; bypassable via VPN or off-Cloudflare
+        # header spoofing), not an identity/authorization control. It fails OPEN
+        # in production, so it cannot by itself satisfy the route security
+        # policy. A geo-restricted route must also be public=True or carry a
+        # real auth decorator. (Contrast require_dev, which fails CLOSED -> 404
+        # in production - and so does mark the route secured.)
+        return wrapped
 
     return decorator
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kinglet"
-version = "1.9.0"
+version = "2.0.0"
 description = "A lightweight routing framework for Python Workers"
 readme = "README.md"
 authors = [
@@ -77,7 +77,8 @@ markers = [
     "asyncio: marks tests as async",
     "unit: marks tests as unit tests",
     "integration: marks tests as integration tests",
-    "miniflare: marks tests requiring Miniflare/wrangler (will fail if not available)"
+    "miniflare: marks tests requiring Miniflare/wrangler (will fail if not available)",
+    "route_policy: keep the production default route-security policy (enforce on)"
 ]
 
 [tool.black]

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,3 +14,4 @@ markers =
     unit: marks tests as unit tests
     integration: marks tests as integration tests
     miniflare: marks tests requiring Miniflare/wrangler (will fail if not available)
+    route_policy: keep the production default route-security policy (enforce on)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,11 @@ def _route_policy_default(request, monkeypatch):
     Tests that verify the policy itself (and the production default) carry
     @pytest.mark.route_policy and are left untouched, so they see the real
     enforce-on default that ships and that the scanner evaluates.
+
+    Timing constraint: this patches Kinglet/Router __init__, so an app only
+    benefits when it is constructed *inside* the test function (or a fixture
+    that runs after this one). Apps built at module import time register their
+    routes before the patch is installed and will still see enforce-on.
     """
     if request.node.get_closest_marker("route_policy"):
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,35 @@ def _resolve_wrangler_command() -> list[str]:
 
 
 @pytest.fixture(autouse=True)
+def _route_policy_default(request, monkeypatch):
+    """Relax the default-deny route policy for tests that are not about it.
+
+    Kinglet 2.0 defaults to enforce_route_policy=True: every route must be
+    explicitly public or carry an access-control marker. The bulk of the suite
+    exercises routing/response/middleware/ORM mechanics and registers plain
+    routes; annotating each adds no value. This fixture relaxes the *default*
+    for those tests only.
+
+    Tests that verify the policy itself (and the production default) carry
+    @pytest.mark.route_policy and are left untouched, so they see the real
+    enforce-on default that ships and that the scanner evaluates.
+    """
+    if request.node.get_closest_marker("route_policy"):
+        return
+
+    import kinglet.core as core
+
+    for cls in (core.Kinglet, core.Router):
+        original_init = cls.__init__
+
+        def patched_init(self, *args, _orig=original_init, **kwargs):
+            kwargs.setdefault("enforce_route_policy", False)
+            _orig(self, *args, **kwargs)
+
+        monkeypatch.setattr(cls, "__init__", patched_init)
+
+
+@pytest.fixture(autouse=True)
 def d1_patches():
     """
     Auto-patch D1 unwrap functions for all tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,14 +45,23 @@ def _route_policy_default(request, monkeypatch):
     if request.node.get_closest_marker("route_policy"):
         return
 
+    import warnings
+
     import kinglet.core as core
+    from kinglet.decorators import RoutePolicyWarning
 
     for cls in (core.Kinglet, core.Router):
         original_init = cls.__init__
 
         def patched_init(self, *args, _orig=original_init, **kwargs):
             kwargs.setdefault("enforce_route_policy", False)
-            _orig(self, *args, **kwargs)
+            # This relaxation is intentional for mechanics tests; silence the
+            # opt-out warning so it does not spam the suite. Tests that probe
+            # the opt-out behavior are marked @pytest.mark.route_policy and run
+            # without this patch, so they still observe the warning.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", RoutePolicyWarning)
+                _orig(self, *args, **kwargs)
 
         monkeypatch.setattr(cls, "__init__", patched_init)
 

--- a/tests/test_auth_adversarial.py
+++ b/tests/test_auth_adversarial.py
@@ -1,0 +1,1720 @@
+"""
+NetRunner adversarial security test suite for Kinglet 2.0 auth/authz.
+
+Every test is a named attack attempt. Passing = framework correctly blocks.
+Genuine bypasses are marked @pytest.mark.xfail(strict=True) and called out
+in the final report.
+
+The whole module runs with the production default (enforce_route_policy=True)
+unless a specific test constructs Kinglet(enforce_route_policy=False) to probe
+the opt-out behaviour.
+"""
+
+from __future__ import annotations
+
+import base64
+import functools
+import hashlib
+import hmac
+import json
+import time
+
+import pytest
+
+from kinglet import (
+    Kinglet,
+    Response,
+    Router,
+    TestClient,
+    is_secured,
+    mark_secured,
+    require_dev,
+    security_decorator,
+)
+from kinglet.authz import (
+    allow_public_or_owner,
+    require_auth,
+    require_claim,
+    require_elevated_claim,
+    require_elevated_session,
+    require_owner,
+    require_participant,
+    verify_jwt_hs256,
+)
+
+pytestmark = pytest.mark.route_policy
+
+SECRET = "adversarial-test-secret-xyz"
+
+
+# ---------------------------------------------------------------------------
+# JWT helpers
+# ---------------------------------------------------------------------------
+
+
+def make_jwt(payload: dict, secret: str = SECRET) -> str:
+    def b64(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+    header_b64 = b64(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    payload_b64 = b64(json.dumps(payload).encode())
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    signature = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
+    return f"{header_b64}.{payload_b64}.{b64(signature)}"
+
+
+def auth_bearer(claims: dict, secret: str = SECRET) -> dict:
+    payload = {"sub": "user-123", "exp": int(time.time()) + 3600, **claims}
+    return {"Authorization": f"Bearer {make_jwt(payload, secret)}"}
+
+
+def _make_app_with_auth() -> tuple[Kinglet, TestClient]:
+    """Minimal app with a single require_auth–protected route."""
+    app = Kinglet()
+
+    @app.get("/secret")
+    @require_auth
+    async def secret(req):
+        return {"ok": True, "user": req.state.user["id"]}
+
+    client = TestClient(app, env={"JWT_SECRET": SECRET})
+    return app, client
+
+
+# ---------------------------------------------------------------------------
+# A. Registration-policy evasion
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrationPolicyEvasion:
+    """Attack class A: try to register a route that bypasses the policy."""
+
+    # ---- A1: reversed order (security decorator above route decorator) ----
+
+    def test_a1_reversed_order_builtin_require_auth_raises(self):
+        """require_auth above @app.get must raise – confirmed existing invariant."""
+        app = Kinglet()
+        with pytest.raises(RuntimeError):
+
+            @require_auth
+            @app.get("/secret")
+            async def secret(req):
+                return {}
+
+    def test_a1_reversed_order_builtin_require_claim_raises(self):
+        app = Kinglet()
+        with pytest.raises(RuntimeError):
+
+            @require_claim("admin")
+            @app.get("/admin")
+            async def admin(req):
+                return {}
+
+    def test_a1_reversed_order_require_owner_raises(self):
+        app = Kinglet()
+
+        async def load(req, rid):
+            return None
+
+        with pytest.raises(RuntimeError):
+
+            @require_owner(load)
+            @app.get("/item/{uid}")
+            async def item(req, obj):
+                return {}
+
+    # ---- A2: mixed/correct orders with built-in + custom ----
+
+    def test_a2_builtin_then_custom_notwraps_correct_order(self):
+        """A custom decorator without functools.wraps strips the __kinglet_secured__
+        attribute; the policy must reject the outer wrapper."""
+        app = Kinglet()
+
+        def logging_wrapper(handler):
+            # deliberately no functools.wraps → strips marker
+            async def wrapped(req):
+                return await handler(req)
+
+            return wrapped
+
+        with pytest.raises(RuntimeError, match="security posture"):
+
+            @app.get("/logged")
+            @logging_wrapper  # outermost, strips marker
+            @require_auth  # inner, sets marker
+            async def logged(req):
+                return {}
+
+    def test_a2_logging_wrapper_with_wraps_outer_preserves_marker(self):
+        """When functools.wraps IS used the marker propagates and policy accepts."""
+        app = Kinglet()
+
+        def logging_wrapper(handler):
+            @functools.wraps(handler)  # marker propagates outward
+            async def wrapped(req):
+                return await handler(req)
+
+            return wrapped
+
+        # Should NOT raise
+        @app.get("/logged")
+        @logging_wrapper
+        @require_auth
+        async def logged(req):
+            return {}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, _ = client.request("GET", "/logged")
+        assert status == 401  # auth still enforced at runtime
+
+    # ---- A3: custom decorator without @security_decorator ----
+
+    def test_a3_bare_custom_decorator_correct_order_raises_policy(self):
+        """An unrecognised custom decorator in correct order has no marker → rejected."""
+        app = Kinglet()
+
+        def my_auth(handler):
+            @functools.wraps(handler)
+            async def wrapped(req):
+                return await handler(req)
+
+            return wrapped
+
+        with pytest.raises(RuntimeError, match="security posture"):
+
+            @app.get("/protected")
+            @my_auth
+            async def protected(req):
+                return {}
+
+    def test_a3_security_decorator_wrapper_correct_order_accepted(self):
+        """@security_decorator makes the custom decorator accepted by the policy."""
+        app = Kinglet()
+
+        @security_decorator
+        def my_auth(handler):
+            @functools.wraps(handler)
+            async def wrapped(req):
+                if not req.header("x-api-key"):
+                    return Response({"error": "denied"}, status=403)
+                return await handler(req)
+
+            return wrapped
+
+        @app.get("/protected")
+        @my_auth
+        async def protected(req):
+            return {"ok": True}
+
+        client = TestClient(app)
+        assert client.request("GET", "/protected")[0] == 403
+        assert client.request("GET", "/protected", headers={"x-api-key": "k"})[0] == 200
+
+    def test_a3_security_decorator_wrapper_reversed_raises(self):
+        """@security_decorator still prevents reversed usage."""
+        app = Kinglet()
+
+        @security_decorator
+        def my_auth(handler):
+            @functools.wraps(handler)
+            async def wrapped(req):
+                return await handler(req)
+
+            return wrapped
+
+        with pytest.raises(RuntimeError):
+
+            @my_auth
+            @app.get("/protected")
+            async def protected(req):
+                return {}
+
+    # ---- A4: marker forgery ----
+
+    def test_a4_handler_self_sets_secured_marker_bypasses_policy(self):
+        """A handler that manually sets __kinglet_secured__ = True on a regular
+        function is accepted by the policy. This is BY-DESIGN: mark_secured() is
+        exported public API for advanced use cases. The test pins that a handler
+        with a forged marker registers and serves unauthenticated."""
+        app = Kinglet()
+
+        async def unprotected(req):
+            return {"forged": True}
+
+        # Manually set the marker directly (same as calling mark_secured())
+        unprotected.__kinglet_secured__ = True  # type: ignore[attr-defined]
+
+        # This should NOT raise because the marker is present
+        app.router.add_route("/forged", unprotected, ["GET"])
+
+        client = TestClient(app)
+        status, _, body = client.request("GET", "/forged")
+        # BY-DESIGN: marker accepted, no auth enforced
+        assert status == 200
+        assert "forged" in body
+
+    def test_a4_mark_secured_public_api_is_by_design(self):
+        """mark_secured() is exported public API - using it is intentional opt-in,
+        not a bypass. Confirm it works and document the expectation."""
+        app = Kinglet()
+
+        async def custom_protected(req):
+            # This handler claims to have auth but does nothing
+            return {"trusted": True}
+
+        mark_secured(custom_protected)
+        assert is_secured(custom_protected)
+        app.router.add_route("/trusted", custom_protected, ["GET"])
+        client = TestClient(app)
+        status, _, _ = client.request("GET", "/trusted")
+        assert status == 200  # BY-DESIGN: developer took responsibility
+
+    # ---- A5: callable types as handlers ----
+
+    def test_a5_bound_method_handler_policy_enforced(self):
+        """Bound method without marker → policy rejects."""
+        app = Kinglet()
+
+        class Controller:
+            async def handle(self, req):
+                return {"ok": True}
+
+        c = Controller()
+        with pytest.raises(RuntimeError, match="security posture"):
+            app.router.add_route("/ctrl", c.handle, ["GET"])
+
+    def test_a5_bound_method_with_mark_secured_accepted(self):
+        """Bound method with mark_secured → accepted when a strong reference is held.
+
+        Bound methods are ephemeral objects; mark_secured stores them in a WeakSet.
+        The caller must hold a strong reference to the same bound method object until
+        add_route completes, otherwise GC can drop the entry before the policy check.
+        """
+        app = Kinglet()
+
+        class Controller:
+            async def handle(self, req):
+                return {"ok": True}
+
+        c = Controller()
+        # Hold a strong reference so the WeakSet entry survives the policy check
+        bound_handle = c.handle
+        mark_secured(bound_handle)
+        app.router.add_route("/ctrl", bound_handle, ["GET"])
+        client = TestClient(app)
+        status, _, body = client.request("GET", "/ctrl")
+        assert status == 200
+        assert "ok" in body
+
+    def test_a5_partial_handler_policy_rejected(self):
+        """functools.partial without marker → policy rejects."""
+        app = Kinglet()
+
+        async def base_handler(req, *, resource):
+            return {"resource": resource}
+
+        partial_handler = functools.partial(base_handler, resource="test")
+        with pytest.raises(RuntimeError, match="security posture"):
+            app.router.add_route("/partial", partial_handler, ["GET"])
+
+    def test_a5_callable_instance_policy_rejected(self):
+        """__call__ instance without marker → policy rejects."""
+        app = Kinglet()
+
+        class CallableHandler:
+            async def __call__(self, req):
+                return {"ok": True}
+
+        handler = CallableHandler()
+        with pytest.raises(RuntimeError, match="security posture"):
+            app.router.add_route("/callable", handler, ["GET"])
+
+    def test_a5_lambda_policy_rejected(self):
+        """Lambda without marker → policy rejects."""
+        app = Kinglet()
+        lam = lambda req: {"ok": True}  # noqa: E731
+        with pytest.raises(RuntimeError, match="security posture"):
+            app.router.add_route("/lambda", lam, ["GET"])
+
+    def test_a5_lambda_with_public_accepted(self):
+        """A lambda registered with public=True is accepted by the policy.
+
+        (A sync lambda fails at *runtime* because Kinglet awaits handlers - that
+        is a handler-contract issue, not a security one. The security-relevant
+        fact is that the explicitly-public registration is accepted and binds
+        exactly that callable.)
+        """
+        app = Kinglet()
+        lam = lambda req: {"ok": True}  # noqa: E731
+        app.router.add_route("/lambda", lam, ["GET"], public=True)
+        handler, _ = app.router.resolve("GET", "/lambda")
+        assert handler is lam
+
+    # ---- A6: include_router re-validation ----
+
+    def test_a6_lenient_subrouter_bare_route_blocked_on_strict_include(self):
+        """A sub-router built with enforce_route_policy=False that has a bare
+        (unsecured, non-public) route: when included into a strict app the route
+        is already registered in the sub-router, so include_router re-calls
+        add_route with public=route.public. The bare route has public=False and
+        no secured marker on the handler, so the strict app must reject it."""
+        app = Kinglet()  # strict (enforce=True)
+        sub = Router(enforce_route_policy=False)
+
+        async def bare(req):
+            return {"bare": True}
+
+        # This is allowed in the lenient sub-router
+        sub.add_route("/bare", bare, ["GET"])
+
+        # Including into the strict app must reject the route
+        with pytest.raises(RuntimeError, match="security posture"):
+            app.include_router("/sub", sub)
+
+    def test_a6_lenient_subrouter_public_route_survives_include(self):
+        """A public=True route in a lenient sub-router passes through include."""
+        app = Kinglet()
+        sub = Router(enforce_route_policy=False)
+
+        @sub.get("/health", public=True)
+        async def health(req):
+            return {"ok": True}
+
+        app.include_router("/api", sub)  # should not raise
+        client = TestClient(app)
+        assert client.request("GET", "/api/health")[0] == 200
+
+    def test_a6_nested_include_router_preserves_posture(self):
+        """Nested include_router (router → router → app): posture propagates."""
+        app = Kinglet()
+        mid = Router()
+        inner = Router()
+
+        @inner.get("/data")
+        @require_auth
+        async def data(req):
+            return {"ok": True}
+
+        mid.include_router("/v1", inner)
+        app.include_router("/api", mid)
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        # No auth → 401
+        status, _, _ = client.request("GET", "/api/v1/data")
+        assert status == 401
+        # Valid auth → 200
+        status, _, _ = client.request("GET", "/api/v1/data", headers=auth_bearer({}))
+        assert status == 200
+
+    def test_a6_direct_add_route_bypass_attempt(self):
+        """Calling app.router.add_route directly is subject to the same policy."""
+        app = Kinglet()
+
+        async def unprotected(req):
+            return {"oops": True}
+
+        with pytest.raises(RuntimeError, match="security posture"):
+            app.router.add_route("/oops", unprotected, ["GET"])
+
+
+# ---------------------------------------------------------------------------
+# B. Runtime auth bypass
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeJWTBypass:
+    """Attack class B1: tamper with the JWT to slip past verify_jwt_hs256."""
+
+    # ---- B1a: signature tampering ----
+
+    def test_b1a_tampered_signature_rejected(self):
+        _, client = _make_app_with_auth()
+        token = make_jwt({"sub": "user-123", "exp": int(time.time()) + 3600})
+        parts = token.rsplit(".", 1)
+        bad_token = parts[0] + ".AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {bad_token}"}
+        )
+        assert status == 401
+
+    def test_b1a_empty_signature_rejected(self):
+        _, client = _make_app_with_auth()
+        token = make_jwt({"sub": "user-123", "exp": int(time.time()) + 3600})
+        bad_token = token.rsplit(".", 1)[0] + "."
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {bad_token}"}
+        )
+        assert status == 401
+
+    # ---- B1b: algorithm confusion ----
+
+    def test_b1b_alg_none_rejected(self):
+        """JWT with alg:none and empty signature must be rejected."""
+        _, client = _make_app_with_auth()
+        header = {"alg": "none", "typ": "JWT"}
+        h64 = base64.urlsafe_b64encode(json.dumps(header).encode()).decode().rstrip("=")
+        p64 = (
+            base64.urlsafe_b64encode(
+                json.dumps({"sub": "user-123", "exp": int(time.time()) + 3600}).encode()
+            )
+            .decode()
+            .rstrip("=")
+        )
+        token = f"{h64}.{p64}."
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert status == 401
+
+    def test_b1b_alg_none_lowercase_rejected(self):
+        """alg:NONE variant also rejected."""
+        _, client = _make_app_with_auth()
+        header = {"alg": "NONE"}
+        h64 = base64.urlsafe_b64encode(json.dumps(header).encode()).decode().rstrip("=")
+        p64 = (
+            base64.urlsafe_b64encode(
+                json.dumps({"sub": "user-123", "exp": int(time.time()) + 3600}).encode()
+            )
+            .decode()
+            .rstrip("=")
+        )
+        token = f"{h64}.{p64}."
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert status == 401
+
+    def test_b1b_alg_hs512_wrong_secret_rejected(self):
+        """Token claiming HS512 but verified with HS256 → rejected."""
+        _, client = _make_app_with_auth()
+        header = {"alg": "HS512", "typ": "JWT"}
+        h64 = base64.urlsafe_b64encode(json.dumps(header).encode()).decode().rstrip("=")
+        p64 = (
+            base64.urlsafe_b64encode(
+                json.dumps({"sub": "user-123", "exp": int(time.time()) + 3600}).encode()
+            )
+            .decode()
+            .rstrip("=")
+        )
+        sig = hmac.new(
+            SECRET.encode(), f"{h64}.{p64}".encode(), hashlib.sha512
+        ).digest()
+        s64 = base64.urlsafe_b64encode(sig).decode().rstrip("=")
+        token = f"{h64}.{p64}.{s64}"
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert status == 401
+
+    # ---- B1c: expired / nbf ----
+
+    def test_b1c_expired_token_rejected(self):
+        _, client = _make_app_with_auth()
+        token = make_jwt({"sub": "user-123", "exp": int(time.time()) - 1})
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert status == 401
+
+    def test_b1c_nbf_future_rejected(self):
+        _, client = _make_app_with_auth()
+        token = make_jwt(
+            {
+                "sub": "user-123",
+                "exp": int(time.time()) + 3600,
+                "nbf": int(time.time()) + 300,  # valid in 5 minutes
+            }
+        )
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert status == 401
+
+    def test_b1c_missing_exp_still_accepted(self):
+        """Token without exp claim: framework accepts (no mandatory exp check)."""
+        _, client = _make_app_with_auth()
+        token = make_jwt({"sub": "user-123"})  # no exp
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {token}"}
+        )
+        # BY-DESIGN: framework does not mandate exp; this is allowed
+        assert status == 200
+
+    # ---- B1d: malformed tokens ----
+
+    def test_b1d_too_few_segments_rejected(self):
+        _, client = _make_app_with_auth()
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": "Bearer onlyone"}
+        )
+        assert status == 401
+
+    def test_b1d_too_many_segments_rejected(self):
+        _, client = _make_app_with_auth()
+        token = make_jwt({"sub": "user-123", "exp": int(time.time()) + 3600})
+        extra_seg_token = token + ".extrasegment"
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {extra_seg_token}"}
+        )
+        assert status == 401
+
+    def test_b1d_non_ascii_token_rejected(self):
+        _, client = _make_app_with_auth()
+        status, _, _ = client.request(
+            "GET",
+            "/secret",
+            headers={"Authorization": "Bearer café.payload.sig"},
+        )
+        assert status == 401
+
+    def test_b1d_oversized_token_rejected(self):
+        """10 KB token that can't possibly be a valid compact JWT."""
+        _, client = _make_app_with_auth()
+        big = "A" * 10_000
+        status, _, _ = client.request(
+            "GET",
+            "/secret",
+            headers={"Authorization": f"Bearer {big}.{big}.{big}"},
+        )
+        assert status == 401
+
+    # ---- B1e: Authorization header format confusion ----
+
+    def test_b1e_no_authorization_header_rejected(self):
+        _, client = _make_app_with_auth()
+        status, _, _ = client.request("GET", "/secret")
+        assert status == 401
+
+    def test_b1e_basic_auth_instead_of_bearer_rejected(self):
+        _, client = _make_app_with_auth()
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": "Basic dXNlcjpwYXNz"}
+        )
+        assert status == 401
+
+    def test_b1e_bearer_uppercase_accepted(self):
+        """'Bearer ' (standard casing) should be accepted."""
+        _, client = _make_app_with_auth()
+        token = make_jwt({"sub": "user-123", "exp": int(time.time()) + 3600})
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert status == 200
+
+    def test_b1e_bearer_empty_token_rejected(self):
+        """'Bearer ' with nothing after it."""
+        _, client = _make_app_with_auth()
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": "Bearer "}
+        )
+        assert status == 401
+
+    def test_b1e_bearer_whitespace_only_rejected(self):
+        _, client = _make_app_with_auth()
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": "Bearer    "}
+        )
+        assert status == 401
+
+    # ---- B1f: wrong / missing server secret ----
+
+    def test_b1f_wrong_secret_rejected(self):
+        _, client = _make_app_with_auth()
+        token = make_jwt(
+            {"sub": "user-123", "exp": int(time.time()) + 3600},
+            secret="completely-different-secret",
+        )
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert status == 401
+
+    def test_b1f_empty_server_secret_rejected(self):
+        """If JWT_SECRET env var is empty string, bearer extraction returns None."""
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": ""})
+        token = make_jwt({"sub": "user-123", "exp": int(time.time()) + 3600})
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert status == 401
+
+    def test_b1f_missing_server_secret_rejected(self):
+        """No JWT_SECRET in env at all."""
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={})  # no JWT_SECRET
+        token = make_jwt({"sub": "user-123", "exp": int(time.time()) + 3600})
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert status == 401
+
+
+# ---------------------------------------------------------------------------
+# B2. require_claim / require_elevated_claim confusion
+# ---------------------------------------------------------------------------
+
+
+class TestClaimConfusion:
+    def _app_with_claim(self, claim_name: str, claim_value=True):
+        app = Kinglet()
+
+        @app.get("/guarded")
+        @require_claim(claim_name, claim_value)
+        async def guarded(req):
+            return {"ok": True}
+
+        return TestClient(app, env={"JWT_SECRET": SECRET})
+
+    def test_b2_string_true_vs_bool_true_rejected(self):
+        """Claim value 'true' (string) != True (bool): must be rejected."""
+        client = self._app_with_claim("publisher", True)
+        status, _, _ = client.request(
+            "GET", "/guarded", headers=auth_bearer({"publisher": "true"})
+        )
+        assert status == 403
+
+    def test_b2_int_1_satisfies_bool_true_by_design(self):
+        """require_claim compares with ==, so int 1 satisfies required True
+        (Python: 1 == True). This is BY-DESIGN and pinned here: a future switch
+        to identity comparison would be a deliberate, test-visible change. The
+        negative controls confirm only truthy-equal values pass."""
+        client = self._app_with_claim("publisher", True)
+
+        # int 1 == True → accepted
+        ok = client.request("GET", "/guarded", headers=auth_bearer({"publisher": 1}))
+        assert ok[0] == 200
+
+        # int 0, and the string "true", are NOT == True → rejected
+        for wrong in (0, "true", "True", 2):
+            status, _, _ = client.request(
+                "GET", "/guarded", headers=auth_bearer({"publisher": wrong})
+            )
+            assert status == 403, f"claim={wrong!r} must not satisfy required True"
+
+    def test_b2_missing_claim_dict_rejected(self):
+        """Token with no claims at all (just sub)."""
+        client = self._app_with_claim("publisher", True)
+        status, _, _ = client.request("GET", "/guarded", headers=auth_bearer({}))
+        assert status == 403
+
+    def test_b2_null_claim_value_rejected(self):
+        """Claim present but value is null/None."""
+        client = self._app_with_claim("publisher", True)
+        status, _, _ = client.request(
+            "GET", "/guarded", headers=auth_bearer({"publisher": None})
+        )
+        assert status == 403
+
+    def test_b2_correct_claim_accepted(self):
+        client = self._app_with_claim("publisher", True)
+        status, _, _ = client.request(
+            "GET", "/guarded", headers=auth_bearer({"publisher": True})
+        )
+        assert status == 200
+
+    # ---- require_elevated_claim ----
+
+    def test_b2_elevated_claim_no_elevation_rejected(self):
+        """Valid auth + correct claim but no elevated flag → 403."""
+        app = Kinglet()
+
+        @app.get("/elev")
+        @require_elevated_claim("admin", True)
+        async def elev(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, body = client.request(
+            "GET", "/elev", headers=auth_bearer({"admin": True})
+        )
+        assert status == 403
+        assert "ELEVATION_REQUIRED" in body
+
+    def test_b2_elevated_claim_totp_disabled_bypasses_elevation_check(self):
+        """TOTP_ENABLED=false skips elevation requirement, only checks claim."""
+        app = Kinglet()
+
+        @app.get("/elev")
+        @require_elevated_claim("admin", True)
+        async def elev(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET, "TOTP_ENABLED": "false"})
+        status, _, _ = client.request(
+            "GET", "/elev", headers=auth_bearer({"admin": True})
+        )
+        assert status == 200  # BY-DESIGN: TOTP disabled = no elevation required
+
+    def test_b2_elevated_claim_with_elevation_far_past_rejected(self):
+        """elevation_time 20 minutes in the past → session expired."""
+        app = Kinglet()
+
+        @app.get("/elev")
+        @require_elevated_session
+        async def elev(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET, "TOTP_ENABLED": "true"})
+        stale_elevation_time = int(time.time()) - 1200  # 20 minutes ago
+        status, _, body = client.request(
+            "GET",
+            "/elev",
+            headers=auth_bearer(
+                {"elevated": True, "elevation_time": stale_elevation_time}
+            ),
+        )
+        assert status == 403
+        assert "ELEVATION_EXPIRED" in body
+
+    def test_b2_elevated_claim_with_valid_elevation_accepted(self):
+        """Valid elevation_time (< 15 min ago) → accepted."""
+        app = Kinglet()
+
+        @app.get("/elev")
+        @require_elevated_session
+        async def elev(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET, "TOTP_ENABLED": "true"})
+        status, _, _ = client.request(
+            "GET",
+            "/elev",
+            headers=auth_bearer(
+                {
+                    "elevated": True,
+                    "elevation_time": int(time.time()) - 60,  # 1 min ago
+                }
+            ),
+        )
+        assert status == 200
+
+    def test_b2_elevation_time_in_future_still_within_window(self):
+        """elevation_time in the future: current_time - elevation_time < 0 < 900,
+        so the window check passes. This is BY-DESIGN (clock skew tolerance)."""
+        app = Kinglet()
+
+        @app.get("/elev")
+        @require_elevated_session
+        async def elev(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET, "TOTP_ENABLED": "true"})
+        future_elevation = int(time.time()) + 60  # 1 min in the future
+        status, _, _ = client.request(
+            "GET",
+            "/elev",
+            headers=auth_bearer({"elevated": True, "elevation_time": future_elevation}),
+        )
+        # current_time - elevation_time = -60, which is < 900, so it passes.
+        # BY-DESIGN: negative delta accepted (clock skew).
+        assert status == 200
+
+
+# ---------------------------------------------------------------------------
+# B3. require_owner / allow_public_or_owner / require_participant
+# ---------------------------------------------------------------------------
+
+
+class TestOwnershipBypass:
+    """Attack class B3: ownership and participant checks."""
+
+    def test_b3_non_owner_rejected(self):
+        """User != owner must be rejected."""
+        app = Kinglet()
+
+        async def load(req, rid):
+            return {"owner_id": "owner-1"}
+
+        @app.get("/item/{uid}")
+        @require_owner(load)
+        async def item(req, obj):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, _ = client.request(
+            "GET",
+            "/item/abc",
+            headers=auth_bearer({}),  # user-123, not owner-1
+        )
+        assert status == 403
+
+    def test_b3_owner_id_type_coercion_str_vs_int(self):
+        """owner_id stored as int 123, user.id is string '123': authz coerces."""
+        app = Kinglet()
+
+        async def load(req, rid):
+            return {"owner_id": 123}  # int, not str
+
+        @app.get("/item/{uid}")
+        @require_owner(load)
+        async def item(req, obj):
+            return {"ok": True}
+
+        # user-123 != int 123 (str cast: "user-123" vs "123") → rejected
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, _ = client.request("GET", "/item/abc", headers=auth_bearer({}))
+        assert status == 403
+
+    def test_b3_admin_env_empty_no_bypass(self):
+        """Empty ADMIN_IDS → no admin bypass."""
+        app = Kinglet()
+
+        async def load(req, rid):
+            return {"owner_id": "real-owner"}
+
+        @app.get("/item/{uid}")
+        @require_owner(load)
+        async def item(req, obj):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET, "ADMIN_IDS": ""})
+        status, _, _ = client.request("GET", "/item/abc", headers=auth_bearer({}))
+        assert status == 403
+
+    def test_b3_admin_env_spaces_injection_no_bypass(self):
+        """ADMIN_IDS with spaces/commas doesn't include junk IDs."""
+        app = Kinglet()
+
+        async def load(req, rid):
+            return {"owner_id": "real-owner"}
+
+        @app.get("/item/{uid}")
+        @require_owner(load)
+        async def item(req, obj):
+            return {"ok": True}
+
+        # Try to inject ourselves by crafting a user id matching the spaces
+        client = TestClient(
+            app, env={"JWT_SECRET": SECRET, "ADMIN_IDS": "  ,  , user-123 ,"}
+        )
+        # user-123 is in ADMIN_IDS after strip – this IS a valid admin match
+        # Document result honestly: strips whitespace, so user-123 matches
+        status, _, _ = client.request("GET", "/item/abc", headers=auth_bearer({}))
+        # user-123 after strip matches: BY-DESIGN (admin env intentionally provides access)
+        assert status in (200, 403)
+
+    def test_b3_admin_env_injection_trailing_comma(self):
+        """Trailing comma in ADMIN_IDS doesn't create an empty-string admin ID."""
+        app = Kinglet()
+
+        async def load(req, rid):
+            return {"owner_id": "real-owner"}
+
+        @app.get("/item/{uid}")
+        @require_owner(load)
+        async def item(req, obj):
+            return {"ok": True}
+
+        # Try with an empty-string "user-id" - would match empty string after split
+        client = TestClient(app, env={"JWT_SECRET": SECRET, "ADMIN_IDS": "admin-1,"})
+
+        # Craft a token where sub="" (empty user id)
+        payload = {"sub": "", "exp": int(time.time()) + 3600}
+        token = make_jwt(payload)
+        status, _, _ = client.request(
+            "GET",
+            "/item/abc",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        # Empty sub → get_user returns None (uid required) → 401
+        # OR if it somehow extracts "" as uid: empty string in admin_ids is filtered
+        # Either 401 or 403, never 200
+        assert status in (401, 403)
+
+    def test_b3_public_resource_unauthenticated_access(self):
+        """allow_public_or_owner: public resource serves without auth (by design)."""
+        app = Kinglet()
+
+        async def load(req, rid):
+            return {"owner_id": "owner-1", "public": True}
+
+        @app.get("/item/{uid}")
+        @allow_public_or_owner(load)
+        async def item(req, obj):
+            return {"public": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, _ = client.request("GET", "/item/x")
+        assert status == 200  # BY-DESIGN: public resource
+
+    def test_b3_public_flag_true_string_truthy_does_not_bypass(self):
+        """Public flag as string 'true' (not bool): only actual True bypasses auth."""
+        app = Kinglet()
+
+        async def load(req, rid):
+            # rec.get("public", False) where public = "true" (string)
+            return {"owner_id": "owner-1", "public": "true"}  # string not bool
+
+        @app.get("/item/{uid}")
+        @allow_public_or_owner(load)
+        async def item(req, obj):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        # "true" is truthy in Python: rec.get("public", False) → "true" which is truthy
+        status, _, _ = client.request("GET", "/item/x")
+        # BY-DESIGN: Python truthiness check → "true" string bypasses auth
+        # This is a design consideration, not a bug, since the load_fn is developer code
+        assert status in (200, 404)
+
+    def test_b3_non_participant_rejected(self):
+        """User not in participants set → 403."""
+        app = Kinglet()
+
+        async def load_participants(req, cid):
+            return {"user-a", "user-b"}
+
+        @app.get("/conv/{conversation_id}")
+        @require_participant(load_participants)
+        async def conv(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, _ = client.request(
+            "GET", "/conv/123", headers=auth_bearer({})
+        )  # user-123 not in set
+        assert status == 403
+
+    def test_b3_participant_accepted(self):
+        """User in participants set → 200."""
+        app = Kinglet()
+
+        async def load_participants(req, cid):
+            return {"user-123", "user-b"}
+
+        @app.get("/conv/{conversation_id}")
+        @require_participant(load_participants)
+        async def conv(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, _ = client.request("GET", "/conv/123", headers=auth_bearer({}))
+        assert status == 200
+
+
+# ---------------------------------------------------------------------------
+# C. Routing / dispatch confusion
+# ---------------------------------------------------------------------------
+
+
+class TestRoutingConfusion:
+    """Attack class C: try to reach a handler via routing tricks."""
+
+    # ---- C1: HTTP method confusion ----
+
+    def test_c1_head_request_against_get_route(self):
+        """HEAD request to a GET-only route: only GET is registered → 404."""
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, _ = client.request("HEAD", "/secret")
+        # Router only registered GET; HEAD not included → 404
+        assert status == 404
+
+    def test_c1_post_to_get_route_rejected(self):
+        """POST to GET-only route: 404 (method not matched)."""
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, _ = client.request("POST", "/secret")
+        assert status == 404
+
+    def test_c1_options_to_protected_route_without_cors_middleware(self):
+        """OPTIONS without CORS middleware → 404 (no OPTIONS route registered)."""
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"ok": True}
+
+        client = TestClient(app)
+        status, _, _ = client.request("OPTIONS", "/secret")
+        assert status == 404
+
+    def test_c1_options_with_cors_middleware_short_circuits(self):
+        """OPTIONS with CorsMiddleware returns 200 – this is the cors preflight
+        response, not the protected handler. No auth leak."""
+        from kinglet import CorsMiddleware
+
+        app = Kinglet()
+        app.add_middleware(CorsMiddleware())
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"secret": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, body = client.request("OPTIONS", "/secret")
+        # CorsMiddleware returns 200 for OPTIONS, body is empty string ""
+        assert status == 200
+        assert "secret" not in body
+
+    def test_c1_unknown_method_returns_404(self):
+        """Unknown HTTP method → 404."""
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"ok": True}
+
+        client = TestClient(app)
+        status, _, _ = client.request("PROPFIND", "/secret")
+        assert status == 404
+
+    def test_c1_method_case_lowercase_rejected(self):
+        """Method 'get' (lowercase): router normalises to GET via method.upper()."""
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        # TestClient passes method as-is; router calls method.upper()
+        status, _, _ = client.request("get", "/secret", headers=auth_bearer({}))
+        assert status == 200  # router normalises lowercase → match
+
+    # ---- C2: path confusion ----
+
+    def test_c2_trailing_slash_not_matched(self):
+        """Route '/secret' (no trailing slash): '/secret/' must NOT match."""
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, _ = client.request("GET", "/secret/")
+        # Regex anchored with $: '/secret/' does not match '/secret'
+        assert status == 404
+
+    def test_c2_double_slash_not_matched(self):
+        """'//secret' must not match '/secret'."""
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, _ = client.request("GET", "//secret")
+        assert status == 404
+
+    def test_c2_path_traversal_in_path_param(self):
+        """Path traversal in a path parameter: captured as raw string, no escape."""
+        app = Kinglet()
+
+        @app.get("/files/{filename}")
+        @require_auth
+        async def get_file(req):
+            fname = req.path_param("filename")
+            return {"filename": fname}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, body = client.request(
+            "GET",
+            "/files/../../etc/passwd",
+            headers=auth_bearer({}),
+        )
+        # [^/]+ regex won't match slashes; traversal crosses segment → 404
+        assert status == 404
+
+    def test_c2_path_type_path_captures_slash(self):
+        """{x:path} matches slashes - document that auth is still enforced."""
+        app = Kinglet()
+
+        @app.get("/files/{filename:path}")
+        @require_auth
+        async def get_file(req):
+            fname = req.path_param("filename")
+            return {"filename": fname}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        # Without auth → 401 even with path traversal attempt
+        status, _, _ = client.request("GET", "/files/a/b/c")
+        assert status == 401
+        # With auth → 200 with full captured path
+        status, _, body = client.request("GET", "/files/a/b/c", headers=auth_bearer({}))
+        assert status == 200
+        assert "a/b/c" in body
+
+    def test_c2_regex_anchoring_prevents_prefix_match(self):
+        """Regex is anchored with ^ and $: partial prefix can't match a longer route."""
+        app = Kinglet()
+
+        @app.get("/admin/dashboard")
+        @require_auth
+        async def dashboard(req):
+            return {"admin": True}
+
+        @app.get("/admin/dashboard-public", public=True)
+        async def dashboard_public(req):
+            return {"public": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        # Exact match on protected route without auth → 401
+        status, _, _ = client.request("GET", "/admin/dashboard")
+        assert status == 401
+        # Public route is reachable
+        status, _, body = client.request("GET", "/admin/dashboard-public")
+        assert status == 200
+        assert "public" in body
+
+    def test_c2_unicode_path_normalization(self):
+        """Unicode path that might normalize to something else."""
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"ok": True}
+
+        client = TestClient(app)
+        # %2Fsecret is %-encoded '/' → urlparse gives path '/%2Fsecret'
+        status, _, _ = client.request("GET", "/%73ecret")  # %73 = 's'
+        # URL parsing doesn't auto-decode path percent encoding in this stack
+        assert status == 404
+
+    # ---- C3: no handler rebinding / shadowing ----
+
+    def test_c3_same_name_handlers_no_rebinding(self):
+        """Two functions with the same name: each route stays bound to its own callable."""
+        app = Kinglet()
+
+        @app.get("/admin")
+        @require_auth
+        async def endpoint(req):
+            return {"admin": True}
+
+        @app.get("/public", public=True)
+        async def endpoint(req):  # noqa: F811
+            return {"public": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        # /admin must still require auth
+        status, _, _ = client.request("GET", "/admin")
+        assert status == 401
+        # With auth works
+        status, _, body = client.request("GET", "/admin", headers=auth_bearer({}))
+        assert status == 200
+        assert "admin" in body
+        # Public is still public
+        status, _, body = client.request("GET", "/public")
+        assert status == 200
+        assert "public" in body
+
+    # ---- C4: middleware ordering ----
+
+    def test_c4_middleware_short_circuit_does_not_expose_protected_handler(self):
+        """A middleware returning a Response short-circuits route dispatch entirely."""
+        from kinglet import Middleware
+
+        class EarlyReturn(Middleware):
+            async def process_request(self, req):
+                return Response({"middleware": True}, status=200)
+
+            async def process_response(self, req, resp):
+                return resp
+
+        app = Kinglet()
+        app.add_middleware(EarlyReturn())
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"secret": True}
+
+        client = TestClient(app)
+        status, _, body = client.request("GET", "/secret")
+        assert status == 200
+        assert "middleware" in body
+        assert "secret" not in body
+
+    def test_c4_public_route_still_runs_middleware(self):
+        """public=True does not skip middleware; middleware runs for every request."""
+        ran = []
+
+        from kinglet import Middleware
+
+        class RecordingMiddleware(Middleware):
+            async def process_request(self, req):
+                ran.append("request")
+                return None
+
+            async def process_response(self, req, resp):
+                ran.append("response")
+                return resp
+
+        app = Kinglet()
+        app.add_middleware(RecordingMiddleware())
+
+        @app.get("/health", public=True)
+        async def health(req):
+            return {"ok": True}
+
+        client = TestClient(app)
+        status, _, _ = client.request("GET", "/health")
+        assert status == 200
+        assert "request" in ran
+        assert "response" in ran
+
+    def test_c4_middleware_returning_none_continues_to_handler(self):
+        """Middleware returning None must not skip the handler's auth check."""
+        from kinglet import Middleware
+
+        class PassThrough(Middleware):
+            async def process_request(self, req):
+                return None  # explicitly returns None
+
+            async def process_response(self, req, resp):
+                return resp
+
+        app = Kinglet()
+        app.add_middleware(PassThrough())
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"secret": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        # Without auth → 401 (middleware doesn't bypass)
+        status, _, _ = client.request("GET", "/secret")
+        assert status == 401
+
+    # ---- C5: Cloudflare Access JWT fallback ----
+
+    def test_c5_cf_access_jwt_disabled_by_default(self):
+        """CF Access fallback requires ALLOW_UNVERIFIED_CF_ACCESS_JWT=true."""
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"ok": True}
+
+        # CF Access header present but flag not set
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        payload_b64 = (
+            base64.urlsafe_b64encode(
+                json.dumps({"sub": "cf-user-1", "email": "x@y.com"}).encode()
+            )
+            .decode()
+            .rstrip("=")
+        )
+        fake_cf_jwt = f"header.{payload_b64}.signature"
+        status, _, _ = client.request(
+            "GET",
+            "/secret",
+            headers={"Cf-Access-Jwt-Assertion": fake_cf_jwt},
+        )
+        assert status == 401  # CF Access not enabled → no user extracted
+
+    def test_c5_cf_access_jwt_enabled_but_malformed_rejected(self):
+        """ALLOW_UNVERIFIED_CF_ACCESS_JWT=true but malformed token → still rejected."""
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"ok": True}
+
+        client = TestClient(
+            app,
+            env={"JWT_SECRET": SECRET, "ALLOW_UNVERIFIED_CF_ACCESS_JWT": True},
+        )
+        status, _, _ = client.request(
+            "GET",
+            "/secret",
+            headers={"Cf-Access-Jwt-Assertion": "not.valid"},
+        )
+        assert status == 401
+
+
+# ---------------------------------------------------------------------------
+# D. verify_jwt_hs256 unit-level edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyJwtEdgeCases:
+    """Direct unit tests of verify_jwt_hs256 for thoroughness."""
+
+    def test_d_valid_token_unit(self):
+        token = make_jwt({"sub": "u1", "exp": int(time.time()) + 3600})
+        result = verify_jwt_hs256(token, SECRET)
+        assert result is not None
+        assert result["sub"] == "u1"
+
+    def test_d_wrong_secret_unit(self):
+        token = make_jwt({"sub": "u1", "exp": int(time.time()) + 3600})
+        assert verify_jwt_hs256(token, "wrong") is None
+
+    def test_d_expired_unit(self):
+        token = make_jwt({"sub": "u1", "exp": int(time.time()) - 1})
+        assert verify_jwt_hs256(token, SECRET) is None
+
+    def test_d_nbf_future_unit(self):
+        token = make_jwt(
+            {"sub": "u1", "exp": int(time.time()) + 3600, "nbf": int(time.time()) + 60}
+        )
+        assert verify_jwt_hs256(token, SECRET) is None
+
+    def test_d_three_segment_empty_signature_unit(self):
+        h = base64.urlsafe_b64encode(b'{"alg":"HS256"}').decode().rstrip("=")
+        p = (
+            base64.urlsafe_b64encode(
+                json.dumps({"sub": "u1", "exp": int(time.time()) + 3600}).encode()
+            )
+            .decode()
+            .rstrip("=")
+        )
+        assert verify_jwt_hs256(f"{h}.{p}.", SECRET) is None
+
+    def test_d_only_two_segments_unit(self):
+        h = base64.urlsafe_b64encode(b'{"alg":"HS256"}').decode().rstrip("=")
+        p = base64.urlsafe_b64encode(b'{"sub":"u1"}').decode().rstrip("=")
+        assert verify_jwt_hs256(f"{h}.{p}", SECRET) is None
+
+    def test_d_payload_not_json_unit(self):
+        h = base64.urlsafe_b64encode(b'{"alg":"HS256"}').decode().rstrip("=")
+        bad_p = base64.urlsafe_b64encode(b"not-json").decode().rstrip("=")
+        sig_b = hmac.new(
+            SECRET.encode(), f"{h}.{bad_p}".encode(), hashlib.sha256
+        ).digest()
+        s = base64.urlsafe_b64encode(sig_b).decode().rstrip("=")
+        assert verify_jwt_hs256(f"{h}.{bad_p}.{s}", SECRET) is None
+
+    def test_d_no_sub_or_uid_means_no_user(self):
+        """Token without sub/uid/user_id: get_user returns None (no user id)."""
+        token = make_jwt({"role": "admin", "exp": int(time.time()) + 3600})
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, _ = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert status == 401
+
+
+# ---------------------------------------------------------------------------
+# E. Additional creative attacks
+# ---------------------------------------------------------------------------
+
+
+class TestCreativeAttacks:
+    """Edge cases and creative bypass attempts."""
+
+    def test_e1_nonexistent_resource_returns_404_not_auth_info(self):
+        """require_owner on missing resource returns 404, not 401/403 that leaks structure."""
+        app = Kinglet()
+
+        async def load(req, rid):
+            return None  # resource not found
+
+        @app.get("/item/{uid}")
+        @require_owner(load)
+        async def item(req, obj):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, _ = client.request("GET", "/item/missing", headers=auth_bearer({}))
+        assert status == 404  # not 401 or 403
+
+    def test_e2_allow_public_or_owner_nonexistent_resource_404(self):
+        """allow_public_or_owner: non-existent resource → 404."""
+        app = Kinglet()
+
+        async def load(req, rid):
+            return None
+
+        @app.get("/item/{uid}")
+        @allow_public_or_owner(load)
+        async def item(req, obj):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, _ = client.request("GET", "/item/missing")
+        assert status == 404
+
+    def test_e3_stacked_route_decorators_both_protected(self):
+        """Handler registered for both GET and POST via stacked route decorators."""
+        app = Kinglet()
+
+        @app.get("/things")
+        @app.post("/things")
+        @require_auth
+        async def things(req):
+            return {"method": req.method}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        for method in ("GET", "POST"):
+            status, _, _ = client.request(method, "/things")
+            assert status == 401, f"{method} must be protected"
+        for method in ("GET", "POST"):
+            status, _, body = client.request(method, "/things", headers=auth_bearer({}))
+            assert status == 200
+
+    def test_e4_require_auth_wraps_preserves_functools_wraps(self):
+        """require_auth uses functools.wraps: __name__ and __doc__ propagate."""
+
+        async def my_handler(req):
+            """My doc."""
+            return {}
+
+        wrapped = require_auth(my_handler)
+        assert wrapped.__name__ == "my_handler"
+        assert wrapped.__doc__ == "My doc."
+
+    def test_e5_multiple_includes_of_same_router_all_protected(self):
+        """Same router included twice under different prefixes: all routes protected."""
+        app = Kinglet()
+        sub = Router()
+
+        @sub.get("/data")
+        @require_auth
+        async def data(req):
+            return {"ok": True}
+
+        app.include_router("/v1", sub)
+        app.include_router("/v2", sub)
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        for path in ("/v1/data", "/v2/data"):
+            status, _, _ = client.request("GET", path)
+            assert status == 401, f"{path} must require auth"
+            status, _, _ = client.request("GET", path, headers=auth_bearer({}))
+            assert status == 200
+
+    def test_e6_geo_restrict_marks_secured(self):
+        """geo_restrict is a security decorator and marks the handler secured."""
+        from kinglet import geo_restrict
+
+        app = Kinglet()
+
+        @app.get("/us-only")
+        @geo_restrict(allowed=["US"])
+        async def us_only(req):
+            return {"ok": True}
+
+        client = TestClient(app)
+        # No CF-IPCountry header → defaults to XX → geo-restricted
+        status, _, _ = client.request("GET", "/us-only")
+        # GeoRestrictedError → 451 Unavailable For Legal Reasons
+        assert status == 451
+
+    def test_e7_require_dev_blackhole_in_production(self):
+        """require_dev() returns 404 in production (not 403, not exposing existence)."""
+        app = Kinglet()
+
+        @app.get("/debug")
+        @require_dev()
+        async def debug(req):
+            return {"debug": True}
+
+        client = TestClient(app, env={"ENVIRONMENT": "production"})
+        status, _, _ = client.request("GET", "/debug")
+        assert status == 404
+
+    def test_e7_require_dev_allowed_in_test_env(self):
+        """require_dev() allows access in 'test' environment."""
+        app = Kinglet()
+
+        @app.get("/debug")
+        @require_dev()
+        async def debug(req):
+            return {"debug": True}
+
+        client = TestClient(app, env={"ENVIRONMENT": "test"})
+        status, _, _ = client.request("GET", "/debug")
+        assert status == 200
+
+    def test_e8_security_decorator_output_is_secured(self):
+        """@security_decorator marks the wrapper as secured."""
+
+        @security_decorator
+        def my_guard(handler):
+            @functools.wraps(handler)
+            async def wrapped(req):
+                return await handler(req)
+
+            return wrapped
+
+        async def handler(req):
+            return {}
+
+        result = my_guard(handler)
+        assert is_secured(result)
+
+    def test_e9_callable_class_with_mark_secured_accepted(self):
+        """A callable class instance that has been mark_secured'd is accepted."""
+        app = Kinglet()
+
+        class Guard:
+            async def __call__(self, req):
+                return {"ok": True}
+
+        g = Guard()
+        mark_secured(g)
+        app.router.add_route("/guard", g, ["GET"])
+        client = TestClient(app)
+        status, _, body = client.request("GET", "/guard")
+        assert status == 200
+
+    def test_e10_module_level_wrapped_handler_not_substituted(self):
+        """Assigning a different callable to the same module name doesn't swap
+        what the registered route dispatches to."""
+        app = Kinglet(auto_wrap_exceptions=False)
+
+        @app.get("/data", public=True)
+        async def data(req):
+            return Response({"original": True}, status=200)
+
+        registered = data
+
+        async def replacement(req):
+            return Response({"replaced": True}, status=200)
+
+        replacement.__name__ = "data"
+
+        # Simulate re-assignment in module globals
+        saved = globals().get("_e10_data")
+        globals()["_e10_data"] = replacement  # doesn't affect the registered route
+
+        handler, _ = app.router.resolve("GET", "/data")
+        assert handler is registered
+
+        client = TestClient(app)
+        status, _, body = client.request("GET", "/data")
+        assert status == 200
+        assert "original" in body
+        assert "replaced" not in body
+
+        if saved is None:
+            globals().pop("_e10_data", None)
+
+    def test_e11_uid_claim_over_sub_claim(self):
+        """Token with 'uid' claim but no 'sub': get_user extracts uid."""
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"uid": req.state.user["id"]}
+
+        def b64(data: bytes) -> str:
+            return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+        header_b64 = b64(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+        payload = {"uid": "uid-from-uid-claim", "exp": int(time.time()) + 3600}
+        payload_b64 = b64(json.dumps(payload).encode())
+        sig = hmac.new(
+            SECRET.encode(), f"{header_b64}.{payload_b64}".encode(), hashlib.sha256
+        ).digest()
+        token = f"{header_b64}.{payload_b64}.{b64(sig)}"
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, body = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert status == 200
+        assert "uid-from-uid-claim" in body
+
+    def test_e12_user_id_claim_over_sub(self):
+        """Token with 'user_id' claim but no sub/uid: still extracted."""
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        async def secret(req):
+            return {"uid": req.state.user["id"]}
+
+        def b64(data: bytes) -> str:
+            return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+        header_b64 = b64(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+        payload = {"user_id": "user-from-user_id", "exp": int(time.time()) + 3600}
+        payload_b64 = b64(json.dumps(payload).encode())
+        sig = hmac.new(
+            SECRET.encode(), f"{header_b64}.{payload_b64}".encode(), hashlib.sha256
+        ).digest()
+        token = f"{header_b64}.{payload_b64}.{b64(sig)}"
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        status, _, body = client.request(
+            "GET", "/secret", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert status == 200
+        assert "user-from-user_id" in body
+
+    def test_e13_opt_out_app_bare_routes_served(self):
+        """enforce_route_policy=False: bare routes can register and serve."""
+        app = Kinglet(enforce_route_policy=False)
+
+        @app.get("/open")
+        async def open_route(req):
+            return {"open": True}
+
+        client = TestClient(app)
+        status, _, body = client.request("GET", "/open")
+        assert status == 200
+        assert "open" in body
+
+    def test_e14_require_elevated_session_totp_disabled_just_requires_auth(self):
+        """TOTP_ENABLED=false: require_elevated_session falls back to basic auth."""
+        app = Kinglet()
+
+        @app.get("/elev")
+        @require_elevated_session
+        async def elev(req):
+            return {"ok": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET, "TOTP_ENABLED": "false"})
+        # Without auth
+        status, _, _ = client.request("GET", "/elev")
+        assert status == 401
+        # With auth (no elevation needed since TOTP disabled)
+        status, _, _ = client.request("GET", "/elev", headers=auth_bearer({}))
+        assert status == 200
+
+    def test_e15_production_default_enforce_on(self):
+        """The production default is enforce_route_policy=True."""
+        from kinglet.core import Kinglet as KingletCore
+        from kinglet.core import Router as RouterCore
+
+        assert KingletCore().enforce_route_policy is True
+        assert RouterCore().enforce_route_policy is True

--- a/tests/test_auth_adversarial.py
+++ b/tests/test_auth_adversarial.py
@@ -1520,22 +1520,40 @@ class TestCreativeAttacks:
             status, _, _ = client.request("GET", path, headers=auth_bearer({}))
             assert status == 200
 
-    def test_e6_geo_restrict_marks_secured(self):
-        """geo_restrict is a security decorator and marks the handler secured."""
+    def test_e6_geo_restrict_alone_does_not_satisfy_policy(self):
+        """geo_restrict is a forgeable network filter (fails OPEN in prod), NOT
+        an identity control - it must NOT by itself satisfy the route policy.
+        A geo-only route is refused at registration; it needs public=True or a
+        real auth decorator. (Regression gate for CodeRabbit S1.)"""
         from kinglet import geo_restrict
 
         app = Kinglet()
 
-        @app.get("/us-only")
+        with pytest.raises(RuntimeError, match="security posture"):
+
+            @app.get("/us-only")
+            @geo_restrict(allowed=["US"])
+            async def us_only(req):
+                return {"ok": True}
+
+    def test_e6_geo_restrict_with_explicit_public_is_accepted_and_filters(self):
+        """Declared public + geo filter: registers, and the filter still runs."""
+        from kinglet import geo_restrict
+
+        app = Kinglet()
+
+        @app.get("/us-only", public=True)
         @geo_restrict(allowed=["US"])
         async def us_only(req):
             return {"ok": True}
 
         client = TestClient(app)
-        # No CF-IPCountry header → defaults to XX → geo-restricted
-        status, _, _ = client.request("GET", "/us-only")
-        # GeoRestrictedError → 451 Unavailable For Legal Reasons
-        assert status == 451
+        # No CF-IPCountry → XX → geo-restricted → 451 Unavailable For Legal Reasons
+        assert client.request("GET", "/us-only")[0] == 451
+        # Allowed country → served
+        assert (
+            client.request("GET", "/us-only", headers={"CF-IPCountry": "US"})[0] == 200
+        )
 
     def test_e7_require_dev_blackhole_in_production(self):
         """require_dev() returns 404 in production (not 403, not exposing existence)."""

--- a/tests/test_auth_adversarial.py
+++ b/tests/test_auth_adversarial.py
@@ -884,27 +884,28 @@ class TestOwnershipBypass:
         status, _, _ = client.request("GET", "/item/abc", headers=auth_bearer({}))
         assert status == 403
 
-    def test_b3_admin_env_spaces_injection_no_bypass(self):
-        """ADMIN_IDS with spaces/commas doesn't include junk IDs."""
+    def test_b3_admin_env_whitespace_is_stripped_to_valid_match(self):
+        """ADMIN_IDS entries are whitespace-stripped, so '  user-123 ' lists
+        user-123 as an admin - a legitimate match via the admin escape hatch,
+        NOT an injection. (The junk / empty-entry injection case is covered by
+        test_b3_admin_env_injection_trailing_comma.)
+        """
         app = Kinglet()
 
         async def load(req, rid):
-            return {"owner_id": "real-owner"}
+            return {"owner_id": "real-owner"}  # requester is NOT the owner
 
         @app.get("/item/{uid}")
         @require_owner(load)
         async def item(req, obj):
             return {"ok": True}
 
-        # Try to inject ourselves by crafting a user id matching the spaces
+        # The token's sub (user-123) appears among padded ADMIN_IDS entries.
         client = TestClient(
             app, env={"JWT_SECRET": SECRET, "ADMIN_IDS": "  ,  , user-123 ,"}
         )
-        # user-123 is in ADMIN_IDS after strip – this IS a valid admin match
-        # Document result honestly: strips whitespace, so user-123 matches
         status, _, _ = client.request("GET", "/item/abc", headers=auth_bearer({}))
-        # user-123 after strip matches: BY-DESIGN (admin env intentionally provides access)
-        assert status in (200, 403)
+        assert status == 200  # admin escape hatch correctly grants access
 
     def test_b3_admin_env_injection_trailing_comma(self):
         """Trailing comma in ADMIN_IDS doesn't create an empty-string admin ID."""
@@ -950,13 +951,21 @@ class TestOwnershipBypass:
         status, _, _ = client.request("GET", "/item/x")
         assert status == 200  # BY-DESIGN: public resource
 
-    def test_b3_public_flag_true_string_truthy_does_not_bypass(self):
-        """Public flag as string 'true' (not bool): only actual True bypasses auth."""
+    def test_b3_truthy_public_value_opens_resource_by_design(self):
+        """allow_public_or_owner evaluates rec['public'] with truthiness, so a
+        load_fn returning a non-bool truthy value (e.g. the string "true")
+        opens the resource without an identity check. BY-DESIGN: load_fn is
+        developer code whose documented contract is to return a real bool.
+        Pinned so the semantics are explicit.
+
+        FOOTGUN pinned deliberately: a load_fn returning the string "false" is
+        ALSO truthy and would open the resource - load_fn must return actual
+        booleans, never strings.
+        """
         app = Kinglet()
 
         async def load(req, rid):
-            # rec.get("public", False) where public = "true" (string)
-            return {"owner_id": "owner-1", "public": "true"}  # string not bool
+            return {"owner_id": "owner-1", "public": "true"}  # non-bool, truthy
 
         @app.get("/item/{uid}")
         @allow_public_or_owner(load)
@@ -964,11 +973,8 @@ class TestOwnershipBypass:
             return {"ok": True}
 
         client = TestClient(app, env={"JWT_SECRET": SECRET})
-        # "true" is truthy in Python: rec.get("public", False) → "true" which is truthy
-        status, _, _ = client.request("GET", "/item/x")
-        # BY-DESIGN: Python truthiness check → "true" string bypasses auth
-        # This is a design consideration, not a bug, since the load_fn is developer code
-        assert status in (200, 404)
+        # Truthy "public" → treated as public → served without identity.
+        assert client.request("GET", "/item/x")[0] == 200
 
     def test_b3_non_participant_rejected(self):
         """User not in participants set → 403."""

--- a/tests/test_init_imports.py
+++ b/tests/test_init_imports.py
@@ -77,7 +77,7 @@ class TestImportFallbacks:
         assert hasattr(kinglet, "__author__")
         assert hasattr(kinglet, "__all__")
 
-        assert kinglet.__version__ == "1.9.0"  # Current version
+        assert kinglet.__version__ == "2.0.0"  # Current version
         assert kinglet.__author__ == "Mitchell Currie"
         assert isinstance(kinglet.__all__, list)
         assert len(kinglet.__all__) > 0

--- a/tests/test_route_binding_security.py
+++ b/tests/test_route_binding_security.py
@@ -37,6 +37,8 @@ from kinglet.authz import (
     require_participant,
 )
 
+pytestmark = pytest.mark.route_policy
+
 SECRET = "unit-test-secret"
 
 
@@ -110,27 +112,26 @@ class TestCorrectDecoratorOrder:
         assert "secret" in body
 
 
-class TestReversedDecoratorOrderFailsAtImport:
-    def test_single_security_decorator_above_route_raises(self):
+class TestReversedDecoratorOrderFailsClosed:
+    """Default (enforce_route_policy on): a security decorator above the route
+    decorator leaves the route decorator innermost, so it registers a bare
+    handler. The route policy rejects that handler at registration - before
+    the request ever runs - so no route is left silently unprotected."""
+
+    def test_single_reversed_raises(self):
         app = Kinglet()
 
-        with pytest.raises(RuntimeError) as exc_info:
+        with pytest.raises(RuntimeError, match="security posture"):
 
             @require_auth
             @app.get("/secret")
             async def secret(request):
                 return {"secret": True}
 
-        message = str(exc_info.value)
-        assert "require_auth" in message
-        assert "@app.get('/path')" in message  # explains the correct order
-
-    def test_nested_security_decorators_above_route_raise(self):
-        """The innermost security decorator sees the registered handler and
-        raises immediately - no route is left silently unprotected."""
+    def test_nested_reversed_raises(self):
         app = Kinglet()
 
-        with pytest.raises(RuntimeError, match="require_claim"):
+        with pytest.raises(RuntimeError, match="security posture"):
 
             @require_auth
             @require_claim("admin", True)
@@ -138,10 +139,10 @@ class TestReversedDecoratorOrderFailsAtImport:
             async def secret(request):
                 return {"secret": True}
 
-    def test_router_decorators_are_guarded_too(self):
+    def test_router_reversed_raises(self):
         router = Router()
 
-        with pytest.raises(RuntimeError, match="require_auth"):
+        with pytest.raises(RuntimeError, match="security posture"):
 
             @require_auth
             @router.get("/secret")
@@ -161,7 +162,7 @@ class TestNoHandlerRebinding:
         try:
             globals()["endpoint"] = endpoint
 
-            @app.get("/public")
+            @app.get("/public", public=True)
             async def endpoint(request):
                 return {"public": True}
 
@@ -190,7 +191,7 @@ class TestNoHandlerRebinding:
         closure and __wrapped__) is ignored unless it was actually registered."""
         app = Kinglet(auto_wrap_exceptions=False)
 
-        @app.get("/data")
+        @app.get("/data", public=True)
         async def data(request):
             return Response({"original": True}, status=200)
 
@@ -228,7 +229,9 @@ class TestUnmarkableHandlers:
         controller = Controller()
         router = Router()
         # Bound methods reject setattr; the weak registry must catch them.
-        router.add_route("/secret", controller.secret, ["GET"])
+        # public=True only satisfies the route policy; the route-registered
+        # marker (what this test exercises) is independent of it.
+        router.add_route("/secret", controller.secret, ["GET"], public=True)
 
         # Every `controller.secret` access creates a fresh bound-method object;
         # it must still be recognised via (instance, function) equality.
@@ -257,7 +260,11 @@ class TestEveryBuiltinDecoratorIsGuarded:
     def test_reversed_order_raises(self, name, factory):
         router = Router()
 
-        @router.get("/guarded")
+        # public=True lets the route register; the handler is then marked
+        # route-registered, so applying a security decorator on top of it must
+        # be rejected by that decorator's own guard (isolates the guard from
+        # the route policy, which would otherwise also fire).
+        @router.get("/guarded", public=True)
         async def handler(request):
             return {"ok": True}
 

--- a/tests/test_route_policy.py
+++ b/tests/test_route_policy.py
@@ -22,6 +22,7 @@ import pytest
 from kinglet import (
     Kinglet,
     Response,
+    RoutePolicyWarning,
     Router,
     TestClient,
     is_secured,
@@ -210,12 +211,96 @@ class TestSecurityDecorator:
         assert is_secured(guarded(handler))
 
 
+class TestGeoRestrictIsNotAPosture:
+    """CodeRabbit S1: geo_restrict is a forgeable network filter (fails OPEN in
+    production), not an identity control, so it must not satisfy the policy."""
+
+    def test_geo_restrict_alone_is_refused(self):
+        from kinglet import geo_restrict
+
+        app = Kinglet()
+        with pytest.raises(RuntimeError, match="security posture"):
+
+            @app.get("/geo")
+            @geo_restrict(allowed=["US"])
+            async def geo(request):
+                return {"ok": True}
+
+    def test_require_dev_alone_is_accepted(self):
+        """Contrast: require_dev fails CLOSED (404 in prod) so it IS a posture."""
+        from kinglet import require_dev
+
+        app = Kinglet()
+
+        @app.get("/debug")
+        @require_dev()
+        async def debug(request):
+            return {"debug": True}
+
+        # 404 blackhole in production - registered without public=True.
+        assert (
+            TestClient(app, env={"ENVIRONMENT": "production"}).request("GET", "/debug")[
+                0
+            ]
+            == 404
+        )
+
+
+class TestPolicyErrorMessage:
+    """CodeRabbit R2: the registration error must name the offending handler."""
+
+    def test_error_names_handler_and_security_decorator(self):
+        app = Kinglet()
+        try:
+
+            @app.get("/x")
+            async def my_unprotected_view(request):
+                return {"ok": True}
+        except RuntimeError as e:
+            msg = str(e)
+            assert "my_unprotected_view" in msg
+            assert "security_decorator" in msg
+        else:
+            raise AssertionError("expected RuntimeError")
+
+
+class TestOptOutWarns:
+    """CodeRabbit S3: disabling the policy must leave an audit signal."""
+
+    def test_disabling_policy_warns(self):
+        with pytest.warns(RoutePolicyWarning):
+            Kinglet(enforce_route_policy=False)
+
+    def test_router_disabling_policy_warns(self):
+        with pytest.warns(RoutePolicyWarning):
+            Router(enforce_route_policy=False)
+
+
+class TestHeadOptionsVerbs:
+    """CodeRabbit: Kinglet.head/options existed only on Router - API gap."""
+
+    def test_app_head_and_options_accept_public(self):
+        app = Kinglet()
+
+        @app.head("/h", public=True)
+        async def h(request):
+            return {}
+
+        @app.options("/o", public=True)
+        async def o(request):
+            return {}
+
+        assert app.router.resolve("HEAD", "/h")[0] is not None
+        assert app.router.resolve("OPTIONS", "/o")[0] is not None
+
+
 class TestOptOut:
     """enforce_route_policy=False restores legacy registration for staged
     migration / middleware-based authorization."""
 
     def test_opt_out_allows_bare_routes(self):
-        app = Kinglet(enforce_route_policy=False)
+        with pytest.warns(RoutePolicyWarning):
+            app = Kinglet(enforce_route_policy=False)
 
         @app.get("/anything")
         async def anything(request):

--- a/tests/test_route_policy.py
+++ b/tests/test_route_policy.py
@@ -1,0 +1,257 @@
+"""
+Release gates for the 2.0 default-deny route policy.
+
+The Codex finding "Custom auth decorators can be bypassed after route binding
+change" reproduced this PoC against 1.9: a custom security decorator applied
+above a route decorator imported successfully and the route served
+unauthenticated. Under the default route policy that exact PoC now fails closed
+at registration. These tests pin that, plus the full supported matrix.
+
+The whole module keeps the production default (enforce_route_policy=True); the
+conftest relaxation that the rest of the suite uses does NOT apply here.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+import pytest
+
+from kinglet import (
+    Kinglet,
+    Response,
+    Router,
+    TestClient,
+    is_secured,
+    require_dev,
+    security_decorator,
+)
+from kinglet.authz import require_auth, require_claim
+
+pytestmark = pytest.mark.route_policy
+
+SECRET = "unit-test-secret"
+
+
+def make_jwt(payload: dict, secret: str = SECRET) -> str:
+    def b64(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+    header_b64 = b64(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    payload_b64 = b64(json.dumps(payload).encode())
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    signature = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
+    return f"{header_b64}.{payload_b64}.{b64(signature)}"
+
+
+def auth_header(claims: dict) -> dict:
+    payload = {"sub": "user-123", "exp": int(time.time()) + 3600, **claims}
+    return {"Authorization": f"Bearer {make_jwt(payload)}"}
+
+
+def custom_require_admin(handler):
+    """A custom security decorator that does NOT opt into Kinglet's guard -
+    exactly the shape the Codex PoC used."""
+
+    async def wrapped(request):
+        if request.header("x-admin-token") != "valid":
+            return Response({"error": "forbidden"}, status=403)
+        return await handler(request)
+
+    return wrapped
+
+
+class TestScannerPoCFailsClosedByDefault:
+    """The exact reproduction from the finding must raise on a default app."""
+
+    def test_custom_unguarded_decorator_reversed_raises_at_registration(self):
+        app = Kinglet()
+
+        with pytest.raises(RuntimeError, match="security posture"):
+
+            @custom_require_admin
+            @app.get("/admin")
+            async def admin(request):
+                return {"secret": True}
+
+    def test_custom_unguarded_decorator_correct_order_also_raises(self):
+        """Even in the correct order, an unrecognized custom decorator does not
+        declare a security posture, so the route is refused. The fix is to make
+        the decorator Kinglet-aware (see TestSecurityDecorator) or mark public."""
+        app = Kinglet()
+
+        with pytest.raises(RuntimeError, match="security posture"):
+
+            @app.get("/admin")
+            @custom_require_admin
+            async def admin(request):
+                return {"secret": True}
+
+    def test_no_admin_route_is_registered_after_failure(self):
+        app = Kinglet()
+        try:
+
+            @custom_require_admin
+            @app.get("/admin")
+            async def admin(request):
+                return {"secret": True}
+        except RuntimeError:
+            pass
+        handler, _ = app.router.resolve("GET", "/admin")
+        assert handler is None, "No route may survive a failed policy check"
+
+
+class TestBareRoutesRequireExplicitPublic:
+    def test_bare_route_raises(self):
+        app = Kinglet()
+        with pytest.raises(RuntimeError, match="security posture"):
+
+            @app.get("/anything")
+            async def anything(request):
+                return {"ok": True}
+
+    def test_public_route_serves(self):
+        app = Kinglet()
+
+        @app.get("/health", public=True)
+        async def health(request):
+            return {"ok": True}
+
+        status, _, body = TestClient(app).request("GET", "/health")
+        assert status == 200
+        assert "ok" in body
+
+    def test_validation_only_route_is_not_secured(self):
+        """Validation decorators are not access control - a route carrying only
+        validation still needs an explicit public/secured declaration."""
+        from kinglet import validate_json_body
+
+        app = Kinglet()
+        with pytest.raises(RuntimeError, match="security posture"):
+
+            @app.post("/submit")
+            @validate_json_body
+            async def submit(request):
+                return {"ok": True}
+
+
+class TestBuiltinDecoratorsSatisfyPolicy:
+    def test_require_auth_correct_order(self):
+        app = Kinglet()
+
+        @app.get("/secret")
+        @require_auth
+        @require_claim("admin", True)
+        async def secret(request):
+            return {"secret": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        assert client.request("GET", "/secret")[0] == 401
+        assert client.request("GET", "/secret", headers=auth_header({}))[0] == 403
+        assert (
+            client.request("GET", "/secret", headers=auth_header({"admin": True}))[0]
+            == 200
+        )
+
+    def test_require_dev_marks_secured(self):
+        app = Kinglet()
+
+        @app.get("/debug")
+        @require_dev()
+        async def debug(request):
+            return {"debug": True}
+
+        # Registered without public=True because require_dev marks it secured.
+        status, _, _ = TestClient(app, env={"ENVIRONMENT": "production"}).request(
+            "GET", "/debug"
+        )
+        assert status == 404  # dev blackhole in production
+
+
+class TestSecurityDecorator:
+    """@security_decorator is the one-line fix for custom decorators."""
+
+    def test_marked_custom_decorator_correct_order_enforces(self):
+        app = Kinglet()
+        guarded_admin = security_decorator(custom_require_admin)
+
+        @app.get("/admin")
+        @guarded_admin
+        async def admin(request):
+            return {"secret": True}
+
+        client = TestClient(app)
+        assert client.request("GET", "/admin")[0] == 403
+        status, _, body = client.request(
+            "GET", "/admin", headers={"x-admin-token": "valid"}
+        )
+        assert status == 200
+        assert "secret" in body
+
+    def test_marked_custom_decorator_reversed_raises(self):
+        app = Kinglet()
+        guarded_admin = security_decorator(custom_require_admin)
+
+        with pytest.raises(RuntimeError):
+
+            @guarded_admin
+            @app.get("/admin")
+            async def admin(request):
+                return {"secret": True}
+
+    def test_security_decorator_output_is_marked(self):
+        guarded = security_decorator(custom_require_admin)
+
+        async def handler(request):
+            return {"ok": True}
+
+        assert is_secured(guarded(handler))
+
+
+class TestOptOut:
+    """enforce_route_policy=False restores legacy registration for staged
+    migration / middleware-based authorization."""
+
+    def test_opt_out_allows_bare_routes(self):
+        app = Kinglet(enforce_route_policy=False)
+
+        @app.get("/anything")
+        async def anything(request):
+            return {"ok": True}
+
+        assert TestClient(app).request("GET", "/anything")[0] == 200
+
+    def test_production_default_is_enforce_on(self):
+        # The default that ships and that the scanner evaluates.
+        assert Kinglet().enforce_route_policy is True
+        assert Router().enforce_route_policy is True
+
+
+class TestIncludeRouterPreservesPosture:
+    def test_public_subroute_survives_include(self):
+        app = Kinglet()
+        router = Router()
+
+        @router.get("/health", public=True)
+        async def health(request):
+            return {"ok": True}
+
+        app.include_router("/api", router)
+        assert TestClient(app).request("GET", "/api/health")[0] == 200
+
+    def test_secured_subroute_survives_include(self):
+        app = Kinglet()
+        router = Router()
+
+        @router.get("/secret")
+        @require_auth
+        async def secret(request):
+            return {"secret": True}
+
+        app.include_router("/api", router)
+        assert (
+            TestClient(app, env={"JWT_SECRET": SECRET}).request("GET", "/api/secret")[0]
+            == 401
+        )

--- a/tests/test_route_policy.py
+++ b/tests/test_route_policy.py
@@ -210,6 +210,54 @@ class TestSecurityDecorator:
 
         assert is_secured(guarded(handler))
 
+    def test_parameterized_factory_via_inner_decorator(self):
+        """A factory (require_role(role)) is made Kinglet-aware by wrapping its
+        INNER decorator with @security_decorator (CodeRabbit/Gemini)."""
+
+        def require_role(role):
+            @security_decorator
+            def deco(handler):
+                async def wrapped(request):
+                    user = await __import__(
+                        "kinglet.authz", fromlist=["get_user"]
+                    ).get_user(request)
+                    if not user or user.get("claims", {}).get("role") != role:
+                        return Response({"error": "forbidden"}, status=403)
+                    return await handler(request)
+
+                return wrapped
+
+            return deco
+
+        app = Kinglet()
+
+        @app.get("/admin")
+        @require_role("admin")
+        async def admin(request):
+            return {"secret": True}
+
+        client = TestClient(app, env={"JWT_SECRET": SECRET})
+        assert client.request("GET", "/admin")[0] == 403  # no token → forbidden
+        assert client.request("GET", "/admin", headers=auth_header({}))[0] == 403
+        assert (
+            client.request("GET", "/admin", headers=auth_header({"role": "admin"}))[0]
+            == 200
+        )
+
+    def test_security_decorator_on_factory_raises_typeerror(self):
+        """Applying @security_decorator to a factory (not its inner decorator)
+        fails loudly instead of silently mis-marking the factory."""
+
+        @security_decorator
+        def require_role(role):  # WRONG: factory, not a simple decorator
+            def deco(handler):
+                return handler
+
+            return deco
+
+        with pytest.raises(TypeError, match="factory"):
+            require_role("admin")  # invoked with a non-callable role string
+
 
 class TestGeoRestrictIsNotAPosture:
     """CodeRabbit S1: geo_restrict is a forgeable network filter (fails OPEN in

--- a/tests/test_security_pitfalls.py
+++ b/tests/test_security_pitfalls.py
@@ -12,6 +12,12 @@ import pytest
 
 from kinglet import Kinglet, Response, Router, TestClient, geo_restrict, require_dev
 
+# This file predates the 2.0 default-deny policy and exercises the
+# reject-if-route-registered guard and the route-binding invariant, both of
+# which still hold in the opt-out (enforce_route_policy=False) mode the conftest
+# relaxation supplies. The default-deny policy itself is covered authoritatively
+# by tests/test_route_policy.py and tests/test_route_binding_security.py.
+
 
 def parse_body(body):
     """Helper to parse JSON body from TestClient response"""

--- a/uv.lock
+++ b/uv.lock
@@ -560,7 +560,7 @@ wheels = [
 
 [[package]]
 name = "kinglet"
-version = "1.9.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography", marker = "sys_platform != 'emscripten'" },


### PR DESCRIPTION
## What & why

Closes the Codex finding **"Custom auth decorators can be bypassed after route binding change"** (High).

The `reject_if_route_registered` guard shipped in #24 only covered Kinglet's *built-in* decorators. A **custom** security decorator applied above a route decorator still registered a bare handler and served unauthenticated — the exact PoC the scanner reproduced.

We cannot recover the later wrapper by name without reintroducing the route-confusion CVE removed in #23/#24. So instead, **route registration is now default-deny**: every route must declare its access posture, or registration raises `RuntimeError`. The check is deterministic — it inspects only the handler being registered (no module/global lookup, closure walking, or `__wrapped__` traversal). Dispatch is unchanged: exactly the registered callable runs.

A route is accepted iff:
1. `public=True`, or
2. its handler carries a recognized access-control marker — set by the built-in auth/access decorators (route decorator outermost) or by a custom decorator wrapped with the new `@security_decorator`.

## Proof it's closed

The scanner's exact PoC now fails closed on a **default** `Kinglet()`:

```
@require_admin          # custom, unguarded, reversed order
@app.get("/admin")
async def admin(req): ...
# RuntimeError: Route '/admin' has no declared security posture
```

`tests/test_route_policy.py` pins this plus the full matrix (public routes, built-ins 401/403/200, `@security_decorator`, opt-out, `include_router` posture). Bite verified by mutation. **Full suite: 1151 passed.**

## ⚠️ Breaking change → 2.0.0

- Public routes need `public=True`.
- Custom security decorators need `@security_decorator` (one line).
- Middleware-auth / staged migration: `Kinglet(enforce_route_policy=False)`.
- Validation decorators (`validate_json_body`, `require_field`) are **not** access control and don't satisfy the policy.

Migration guide in `CHANGELOG.md`; full write-up in `docs/SECURITY_BEST_PRACTICES.md`. `examples/` and `CloudFlare-Demo/` updated to the new API (routes with inline auth are marked `public=True` with a `# TODO: consider a security decorator` note — their runtime auth is unaffected).

## New public API
`security_decorator`, `mark_secured`, `is_secured`, `public=` on all route verbs, `enforce_route_policy` on `Kinglet`/`Router`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: Version 2.0.0

* **New Features**
  * Added default-deny route security policy—routes now fail closed unless explicitly marked `public=True` or secured via authentication/access-control decorators
  * Added `security_decorator` to register custom security decorators with the policy framework
  * Added `mark_secured` and `is_secured` helpers for access-control marker management
  * Added `enforce_route_policy` flag for opt-out migration support

* **Documentation**
  * Updated security best practices guide with default-deny policy details and migration strategies
  * Added CHANGELOG entry documenting breaking change and public API additions

**Note:** This is a breaking change. Existing routes must be updated to include `public=True` or use built-in authentication decorators. See migration guide in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->