### PR TITLE
Harden secured marker against functools.wraps laundering (High)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,12 @@ For each route, do **one** of the following:
 - Disabling the policy (`enforce_route_policy=False`) emits a
   `RoutePolicyWarning` so an intentional opt-out is not mistaken for one
   forgotten during migration.
+- The "secured" posture is tracked by **object identity** in an internal
+  registry, set via `mark_secured()` / `@security_decorator`. There is no public
+  `__kinglet_secured__` attribute: hand-setting that attribute does nothing
+  (use `mark_secured()`), and it cannot be laundered onto an outer wrapper by
+  `functools.wraps`. The route-registered order guard uses a weak registry for
+  the same reason (no `functools.wraps` false positives).
 - `Kinglet` now also exposes `head()` and `options()` route decorators (were
   previously only on `Router`).
 - The registration error names the offending handler and points at

--- a/kinglet/core.py
+++ b/kinglet/core.py
@@ -32,6 +32,13 @@ class Route:
         self, path: str, handler: Callable, methods: list[str], public: bool = False
     ):
         self.path = path
+        # Invariant: self.handler must remain the exact object passed to
+        # mark_route_registered. The route-registered marker is a weak registry;
+        # for bound-method handlers the entry survives only while this strong
+        # reference does. Storing a re-wrapped/copied handler here while marking
+        # the original would let the entry be collected early and silently
+        # weaken the decorator-order guard (fail-loud -> fail-silent; still not
+        # an auth bypass, since the route policy is the backstop).
         self.handler = mark_route_registered(handler)
         self.methods = [m.upper() for m in methods]
         self.public = public  # explicit access posture, preserved for include_router

--- a/kinglet/decorators.py
+++ b/kinglet/decorators.py
@@ -2,7 +2,6 @@
 Kinglet Decorators and Utility Functions
 """
 
-import contextlib
 import functools
 import json
 import weakref
@@ -11,39 +10,39 @@ from collections.abc import Callable
 from .exceptions import GeoRestrictedError, HTTPError
 from .http import Response
 
-# Attribute set on every callable registered with a route. Security decorators
-# use it to fail closed when applied in an order that cannot protect the route.
-ROUTE_REGISTERED_ATTR = "__kinglet_route_registered__"
-
-# Fallback registry for callables that cannot carry attributes (bound methods,
-# functools.partial, ...). Weak references: entries vanish when the registered
-# handler is garbage collected. Bound methods are ephemeral objects but hash
-# and compare by (instance, function), so a fresh `obj.method` reference still
-# matches the one the route registered.
-_UNMARKABLE_ROUTE_HANDLERS: weakref.WeakSet = weakref.WeakSet()
+# Registry of callables registered to a route, used by the decorator-order
+# guard. A WeakSet (value-equality membership) so a fresh access of a registered
+# bound method still matches via (instance, function) equality. Crucially,
+# WeakSet membership is NOT copied by functools.wraps - unlike a function
+# attribute, which wraps copies into outer wrappers and which previously made
+# the order guard reject a wrapper that merely inherited the copied attribute.
+#
+# Contrast _SECURED_HANDLERS, which must use STRICT identity to stop value-
+# equality laundering of the auth posture. Here value-equality is fine: it only
+# ever over-triggers the fail-loud order guard (never a bypass), so matching a
+# fresh bound-method access is the desired behaviour.
+_ROUTE_REGISTERED_HANDLERS: weakref.WeakSet = weakref.WeakSet()
 
 
 def mark_route_registered(handler: Callable) -> Callable:
     """Mark a callable as registered with a route.
 
-    Callables that reject attribute assignment are tracked in a weak registry
-    instead, so the decorator-order guard still detects them.
+    Membership is held weakly and is not propagated by functools.wraps, so the
+    decorator-order guard recognizes exactly the registered callables (and fresh
+    accesses of registered bound methods) without false positives from wrapping.
     """
     try:
-        setattr(handler, ROUTE_REGISTERED_ATTR, True)
-    except (AttributeError, TypeError):
-        # Not weakref-able or not hashable: best effort ends here.
-        with contextlib.suppress(TypeError):
-            _UNMARKABLE_ROUTE_HANDLERS.add(handler)
+        _ROUTE_REGISTERED_HANDLERS.add(handler)
+    except TypeError:
+        # Not weakref-able / not hashable: cannot be tracked (order guard skipped).
+        pass
     return handler
 
 
 def is_route_registered(handler: Callable) -> bool:
     """Return True if the callable was already registered with a route."""
-    if getattr(handler, ROUTE_REGISTERED_ATTR, False):
-        return True
     try:
-        return handler in _UNMARKABLE_ROUTE_HANDLERS
+        return handler in _ROUTE_REGISTERED_HANDLERS
     except TypeError:  # unhashable callable
         return False
 
@@ -111,17 +110,41 @@ def mark_secured(handler: Callable) -> Callable:
 
     Recognized built-in access decorators call this on their wrapper, and
     :func:`security_decorator` calls it for custom decorators. The route
-    policy then accepts the route without requiring ``public=True``. The mark
-    is recorded by object identity, so wrapping the result in an unrelated
-    decorator does NOT carry the posture across - the wrapper must enforce
-    (or re-mark) auth itself.
+    policy then accepts the route without requiring ``public=True``.
+
+    The mark is recorded by object **identity** (not value or a copyable
+    attribute), so wrapping the result in an unrelated decorator does NOT carry
+    the posture across - the wrapper must enforce (or re-mark) auth itself. Two
+    consequences for callers:
+
+    - **Bound methods**: ``obj.method`` creates a NEW object on each access, so
+      ``mark_secured(obj.method)`` marks one object while a later ``obj.method``
+      is a different one that is not secured. Capture the reference once and
+      pass the SAME object to both ``mark_secured`` and route registration::
+
+          handler = controller.action
+          mark_secured(handler)
+          router.add_route("/x", handler, ["GET"])
+
+    - **Non-weakref-able callables** cannot be tracked: the mark is skipped (a
+      :class:`RoutePolicyWarning` is emitted) and the route must instead be
+      declared ``public=True``. This fails closed.
     """
     try:
         _SECURED_HANDLERS[id(handler)] = handler
     except TypeError:
         # Not weakref-able (exotic callable): cannot be marked, so it is treated
-        # as unsecured and the route must be declared public=True. Fail closed.
-        pass
+        # as unsecured and the route must be declared public=True. Fail closed,
+        # but surface it so the later "no security posture" error is not a
+        # mystery.
+        import warnings
+
+        warnings.warn(
+            f"mark_secured: {handler!r} is not weakref-able and cannot be "
+            f"tracked as secured; the route must be declared public=True.",
+            RoutePolicyWarning,
+            stacklevel=2,
+        )
     return handler
 
 

--- a/kinglet/decorators.py
+++ b/kinglet/decorators.py
@@ -86,20 +86,24 @@ class RoutePolicyWarning(UserWarning):
     """
 
 
-# Identity registry of callables that a recognized access-control decorator
-# actually produced. Membership is by OBJECT IDENTITY and is therefore NOT
-# copied by ``functools.wraps`` (which only copies ``__dict__`` and a few dunder
-# attributes). This is deliberate: storing the posture as a function attribute
-# let an unrelated outer wrapper - e.g. a short-circuiting cache/maintenance/
-# feature-flag decorator that uses ``functools.wraps`` but never calls the inner
-# handler - launder the "secured" marker onto itself and bypass auth. With an
-# identity registry, such a wrapper is a different object that was never marked,
-# so it fails the policy closed.
+# Registry of callables that a recognized access-control decorator actually
+# produced. Keyed by ``id()`` and verified with ``is``, so membership is by true
+# OBJECT IDENTITY - never value equality. This matters twice:
 #
-# Weak references: entries die with the callable. The check runs synchronously
-# at route registration while the route holds a strong reference to the
-# registered callable, so liveness is never a concern at check time.
-_SECURED_HANDLERS: weakref.WeakSet = weakref.WeakSet()
+#   * ``functools.wraps`` copies ``__dict__`` and a few dunders but not registry
+#     identity, so an unrelated outer wrapper (e.g. a short-circuiting cache /
+#     maintenance / feature-flag decorator) cannot launder the "secured" posture
+#     onto itself and bypass auth.
+#   * A plain ``WeakSet`` would use the element's ``__eq__``/``__hash__``, so a
+#     distinct callable that merely *compares equal* to a marked one (a callable
+#     class with value-based equality, a bound method, ...) would pass the check
+#     unmarked. Id-keying + an ``is`` check accepts only the exact object.
+#
+# Values are held weakly so entries die with the callable; the ``is`` check also
+# guards against id reuse after garbage collection. The check runs synchronously
+# at registration while the route holds a strong reference, so liveness is never
+# a concern at check time.
+_SECURED_HANDLERS: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
 
 
 def mark_secured(handler: Callable) -> Callable:
@@ -113,7 +117,7 @@ def mark_secured(handler: Callable) -> Callable:
     (or re-mark) auth itself.
     """
     try:
-        _SECURED_HANDLERS.add(handler)
+        _SECURED_HANDLERS[id(handler)] = handler
     except TypeError:
         # Not weakref-able (exotic callable): cannot be marked, so it is treated
         # as unsecured and the route must be declared public=True. Fail closed.
@@ -122,11 +126,8 @@ def mark_secured(handler: Callable) -> Callable:
 
 
 def is_secured(handler: Callable) -> bool:
-    """Return True if the callable was produced by a recognized access decorator."""
-    try:
-        return handler in _SECURED_HANDLERS
-    except TypeError:
-        return False
+    """Return True if this exact callable was produced by a recognized decorator."""
+    return _SECURED_HANDLERS.get(id(handler)) is handler
 
 
 def security_decorator(decorator_fn: Callable) -> Callable:
@@ -220,6 +221,32 @@ def assert_route_security(handler: Callable, *, public: bool, path: str = "") ->
     )
 
 
+def _should_expose_details(request, expose_details: bool | None) -> bool:
+    """Resolve whether exception detail should be exposed in the response."""
+    if expose_details is not None:
+        return expose_details
+    # Fall back to the request environment / app debug setting.
+    return getattr(request.env, "ENVIRONMENT", "production") == "development"
+
+
+def _exception_error_response(exc: Exception, request, step, expose_details):
+    """Build the standardized 500 response for a handler exception."""
+    error_message = (
+        str(exc)
+        if _should_expose_details(request, expose_details)
+        else ("Internal server error")
+    )
+    prefix = f"[{step}] " if step else ""
+    return Response(
+        {
+            "error": f"{prefix}{error_message}",
+            "status_code": 500,
+            "request_id": getattr(request, "request_id", "unknown"),
+        },
+        status=500,
+    )
+
+
 def wrap_exceptions(step: str = None, expose_details: bool = None):
     """
     Decorator to automatically wrap exceptions in standardized error responses.
@@ -247,26 +274,7 @@ def wrap_exceptions(step: str = None, expose_details: bool = None):
                 # Re-raise HTTP errors as-is (already properly formatted)
                 raise
             except Exception as e:
-                # Determine if we should expose details
-                should_expose = expose_details
-                if should_expose is None:
-                    # Fall back to checking request environment or app debug setting
-                    should_expose = (
-                        getattr(request.env, "ENVIRONMENT", "production")
-                        == "development"
-                    )
-
-                error_message = str(e) if should_expose else "Internal server error"
-                prefix = f"[{step}] " if step else ""
-
-                return Response(
-                    {
-                        "error": f"{prefix}{error_message}",
-                        "status_code": 500,
-                        "request_id": getattr(request, "request_id", "unknown"),
-                    },
-                    status=500,
-                )
+                return _exception_error_response(e, request, step, expose_details)
 
         if inner_secured:
             mark_secured(wrapped)

--- a/kinglet/decorators.py
+++ b/kinglet/decorators.py
@@ -86,13 +86,20 @@ class RoutePolicyWarning(UserWarning):
     """
 
 
-# Set on the wrapper produced by a recognized access-control decorator. Stored
-# as a normal function attribute so it lives in ``__dict__`` and therefore
-# propagates outward through ``functools.wraps`` when decorators are stacked.
-SECURED_ATTR = "__kinglet_secured__"
-
-# Fallback registry for secured callables that cannot carry attributes.
-_UNMARKABLE_SECURED_HANDLERS: weakref.WeakSet = weakref.WeakSet()
+# Identity registry of callables that a recognized access-control decorator
+# actually produced. Membership is by OBJECT IDENTITY and is therefore NOT
+# copied by ``functools.wraps`` (which only copies ``__dict__`` and a few dunder
+# attributes). This is deliberate: storing the posture as a function attribute
+# let an unrelated outer wrapper - e.g. a short-circuiting cache/maintenance/
+# feature-flag decorator that uses ``functools.wraps`` but never calls the inner
+# handler - launder the "secured" marker onto itself and bypass auth. With an
+# identity registry, such a wrapper is a different object that was never marked,
+# so it fails the policy closed.
+#
+# Weak references: entries die with the callable. The check runs synchronously
+# at route registration while the route holds a strong reference to the
+# registered callable, so liveness is never a concern at check time.
+_SECURED_HANDLERS: weakref.WeakSet = weakref.WeakSet()
 
 
 def mark_secured(handler: Callable) -> Callable:
@@ -100,22 +107,24 @@ def mark_secured(handler: Callable) -> Callable:
 
     Recognized built-in access decorators call this on their wrapper, and
     :func:`security_decorator` calls it for custom decorators. The route
-    policy then accepts the route without requiring ``public=True``.
+    policy then accepts the route without requiring ``public=True``. The mark
+    is recorded by object identity, so wrapping the result in an unrelated
+    decorator does NOT carry the posture across - the wrapper must enforce
+    (or re-mark) auth itself.
     """
     try:
-        setattr(handler, SECURED_ATTR, True)
-    except (AttributeError, TypeError):
-        with contextlib.suppress(TypeError):
-            _UNMARKABLE_SECURED_HANDLERS.add(handler)
+        _SECURED_HANDLERS.add(handler)
+    except TypeError:
+        # Not weakref-able (exotic callable): cannot be marked, so it is treated
+        # as unsecured and the route must be declared public=True. Fail closed.
+        pass
     return handler
 
 
 def is_secured(handler: Callable) -> bool:
-    """Return True if the callable carries a recognized access-control marker."""
-    if getattr(handler, SECURED_ATTR, False):
-        return True
+    """Return True if the callable was produced by a recognized access decorator."""
     try:
-        return handler in _UNMARKABLE_SECURED_HANDLERS
+        return handler in _SECURED_HANDLERS
     except TypeError:
         return False
 
@@ -221,6 +230,15 @@ def wrap_exceptions(step: str = None, expose_details: bool = None):
     """
 
     def decorator(handler):
+        # wrap_exceptions is framework-applied, transparent infrastructure: it
+        # ALWAYS calls the inner handler (try/except around it), so it cannot
+        # hide an access check. It must therefore preserve the inner handler's
+        # security posture - otherwise auto-wrapping every route would strip the
+        # marker and break auth'd routes. Capture it before wrapping and re-mark
+        # by identity. (An ordinary user decorator is NOT trusted this way - only
+        # this provably-transparent wrapper is.)
+        inner_secured = is_secured(handler)
+
         @functools.wraps(handler)
         async def wrapped(request):
             try:
@@ -250,6 +268,8 @@ def wrap_exceptions(step: str = None, expose_details: bool = None):
                     status=500,
                 )
 
+        if inner_secured:
+            mark_secured(wrapped)
         return wrapped
 
     return decorator

--- a/kinglet/decorators.py
+++ b/kinglet/decorators.py
@@ -4,6 +4,7 @@ Kinglet Decorators and Utility Functions
 
 import functools
 import json
+import warnings
 import weakref
 from collections.abc import Callable
 
@@ -34,8 +35,15 @@ def mark_route_registered(handler: Callable) -> Callable:
     try:
         _ROUTE_REGISTERED_HANDLERS.add(handler)
     except TypeError:
-        # Not weakref-able / not hashable: cannot be tracked (order guard skipped).
-        pass
+        # Not weakref-able / not hashable: cannot be tracked, so the
+        # decorator-order guard is skipped for this callable. Surface it for
+        # consistency with mark_secured (still fail-loud only - never a bypass).
+        warnings.warn(
+            f"mark_route_registered: {handler!r} is not trackable; the "
+            f"decorator-order guard is skipped for this callable.",
+            RoutePolicyWarning,
+            stacklevel=2,
+        )
     return handler
 
 
@@ -137,8 +145,6 @@ def mark_secured(handler: Callable) -> Callable:
         # as unsecured and the route must be declared public=True. Fail closed,
         # but surface it so the later "no security posture" error is not a
         # mystery.
-        import warnings
-
         warnings.warn(
             f"mark_secured: {handler!r} is not weakref-able and cannot be "
             f"tracked as secured; the route must be declared public=True.",
@@ -327,8 +333,7 @@ def require_dev():
             if env_name not in ["development", "dev", "test"]:
                 # Security: In production, make dev endpoints a complete blackhole
                 # Return 404 as if the endpoint doesn't exist at all
-                from .exceptions import HTTPError
-
+                # (HTTPError is imported at module top.)
                 raise HTTPError(404, "Not Found", getattr(request, "request_id", None))
 
             return await handler(request)

--- a/tests/test_auth_adversarial.py
+++ b/tests/test_auth_adversarial.py
@@ -302,11 +302,13 @@ class TestRegistrationPolicyEvasion:
             app.router.add_route("/ctrl", c.handle, ["GET"])
 
     def test_a5_bound_method_with_mark_secured_accepted(self):
-        """Bound method with mark_secured → accepted when a strong reference is held.
+        """Bound method with mark_secured → accepted when the SAME object is used.
 
-        Bound methods are ephemeral objects; mark_secured stores them in a WeakSet.
-        The caller must hold a strong reference to the same bound method object until
-        add_route completes, otherwise GC can drop the entry before the policy check.
+        Bound methods are ephemeral (each ``c.handle`` access is a new object).
+        mark_secured records them in a WeakValueDictionary keyed by id() and
+        is_secured matches by identity, so the caller must pass the exact same
+        bound-method object to both mark_secured and add_route (capturing it
+        once also keeps the weak entry alive until the policy check).
         """
         app = Kinglet()
 
@@ -315,7 +317,8 @@ class TestRegistrationPolicyEvasion:
                 return {"ok": True}
 
         c = Controller()
-        # Hold a strong reference so the WeakSet entry survives the policy check
+        # Capture once: the SAME object must reach mark_secured and add_route
+        # (identity-keyed registry), and the strong ref keeps the entry alive.
         bound_handle = c.handle
         mark_secured(bound_handle)
         app.router.add_route("/ctrl", bound_handle, ["GET"])

--- a/tests/test_auth_adversarial.py
+++ b/tests/test_auth_adversarial.py
@@ -126,12 +126,13 @@ class TestRegistrationPolicyEvasion:
     # ---- A2: mixed/correct orders with built-in + custom ----
 
     def test_a2_builtin_then_custom_notwraps_correct_order(self):
-        """A custom decorator without functools.wraps strips the __kinglet_secured__
-        attribute; the policy must reject the outer wrapper."""
+        """A custom (non-Kinglet) decorator wrapping a real auth decorator is a
+        different, unmarked object, so the policy rejects the outer wrapper -
+        whether or not it uses functools.wraps (the posture is tracked by
+        identity, not a copyable attribute)."""
         app = Kinglet()
 
         def logging_wrapper(handler):
-            # deliberately no functools.wraps → strips marker
             async def wrapped(req):
                 return await handler(req)
 
@@ -145,27 +146,51 @@ class TestRegistrationPolicyEvasion:
             async def logged(req):
                 return {}
 
-    def test_a2_logging_wrapper_with_wraps_outer_preserves_marker(self):
-        """When functools.wraps IS used the marker propagates and policy accepts."""
+    def test_a2_wraps_wrapper_outside_auth_fails_closed(self):
+        """A wrapper using functools.wraps OUTSIDE a real auth decorator no
+        longer inherits the secured posture. The posture is tracked by object
+        identity (a registry), not a functools.wraps-copyable attribute, so an
+        outer wrapper is a different, unmarked object. The framework cannot tell
+        a call-through wrapper from a short-circuiting one at registration, so it
+        conservatively fails closed (this is what blocks the marker-laundering
+        bypass)."""
         app = Kinglet()
 
         def logging_wrapper(handler):
-            @functools.wraps(handler)  # marker propagates outward
+            @functools.wraps(handler)  # copies __dict__, but not registry identity
             async def wrapped(req):
                 return await handler(req)
 
             return wrapped
 
-        # Should NOT raise
+        with pytest.raises(RuntimeError, match="security posture"):
+
+            @app.get("/logged")
+            @logging_wrapper
+            @require_auth
+            async def logged(req):
+                return {}
+
+    def test_a2_auth_outermost_is_accepted(self):
+        """The correct fix for the above: put the auth decorator outside the
+        plain wrapper so the registered callable is the secured one."""
+        app = Kinglet()
+
+        def logging_wrapper(handler):
+            @functools.wraps(handler)
+            async def wrapped(req):
+                return await handler(req)
+
+            return wrapped
+
         @app.get("/logged")
+        @require_auth  # outermost of the two → registered callable is secured
         @logging_wrapper
-        @require_auth
         async def logged(req):
             return {}
 
         client = TestClient(app, env={"JWT_SECRET": SECRET})
-        status, _, _ = client.request("GET", "/logged")
-        assert status == 401  # auth still enforced at runtime
+        assert client.request("GET", "/logged")[0] == 401  # auth enforced
 
     # ---- A3: custom decorator without @security_decorator ----
 
@@ -231,27 +256,20 @@ class TestRegistrationPolicyEvasion:
 
     # ---- A4: marker forgery ----
 
-    def test_a4_handler_self_sets_secured_marker_bypasses_policy(self):
-        """A handler that manually sets __kinglet_secured__ = True on a regular
-        function is accepted by the policy. This is BY-DESIGN: mark_secured() is
-        exported public API for advanced use cases. The test pins that a handler
-        with a forged marker registers and serves unauthenticated."""
+    def test_a4_forged_attribute_no_longer_bypasses_policy(self):
+        """Setting __kinglet_secured__ by hand no longer fools the policy: the
+        posture is tracked by object identity in a registry, not a copyable
+        attribute, so a forged attribute is simply ignored and the route fails
+        closed. (The supported opt-in is mark_secured(), see the next test.)"""
         app = Kinglet()
 
         async def unprotected(req):
             return {"forged": True}
 
-        # Manually set the marker directly (same as calling mark_secured())
-        unprotected.__kinglet_secured__ = True  # type: ignore[attr-defined]
+        unprotected.__kinglet_secured__ = True  # forged attribute - now ignored
 
-        # This should NOT raise because the marker is present
-        app.router.add_route("/forged", unprotected, ["GET"])
-
-        client = TestClient(app)
-        status, _, body = client.request("GET", "/forged")
-        # BY-DESIGN: marker accepted, no auth enforced
-        assert status == 200
-        assert "forged" in body
+        with pytest.raises(RuntimeError, match="security posture"):
+            app.router.add_route("/forged", unprotected, ["GET"])
 
     def test_a4_mark_secured_public_api_is_by_design(self):
         """mark_secured() is exported public API - using it is intentional opt-in,

--- a/tests/test_route_binding_security.py
+++ b/tests/test_route_binding_security.py
@@ -272,6 +272,58 @@ class TestUnmarkableHandlers:
         require_auth(wrapper)
 
 
+class TestRouteHandlerMarkedInvariant:
+    """Pin the load-bearing invariant: ``Route.handler`` is exactly the object
+    that was marked route-registered. The marker is a weak registry whose entry
+    (for bound methods) is kept alive only by that strong reference, so a future
+    refactor that stored a different/copied handler while marking the original
+    would silently weaken the decorator-order guard. These tests fail if that
+    invariant is ever broken."""
+
+    def test_registered_function_handler_is_marked(self):
+        router = Router()
+
+        @router.get("/fn", public=True)
+        async def fn(request):
+            return {}
+
+        route = router.routes[-1]
+        assert is_route_registered(route.handler), (
+            "Route.handler must be the object that was marked route-registered"
+        )
+
+    def test_app_route_handler_is_marked_through_auto_wrap(self):
+        # Kinglet.route auto-wraps with wrap_exceptions, so the REGISTERED
+        # handler is the wrapper - it must itself be the marked object.
+        app = Kinglet()
+
+        @app.get("/x", public=True)
+        async def x(request):
+            return {}
+
+        route = app.router.routes[-1]
+        assert is_route_registered(route.handler)
+
+    def test_registered_bound_method_entry_survives_gc(self):
+        import gc
+
+        class Controller:
+            async def handle(self, request):
+                return {}
+
+        router = Router()
+        controller = Controller()
+        router.add_route("/bm", controller.handle, ["GET"], public=True)
+        route = router.routes[-1]
+
+        # Drop the external handle; the bound method (and its instance) now stay
+        # alive ONLY via Route.handler. The weak registry entry must survive,
+        # which is exactly the invariant the Route's strong ref guarantees.
+        del controller
+        gc.collect()
+        assert is_route_registered(route.handler)
+
+
 class TestEveryBuiltinDecoratorIsGuarded:
     """One red test per decorator if its guard call is ever removed."""
 

--- a/tests/test_route_binding_security.py
+++ b/tests/test_route_binding_security.py
@@ -248,6 +248,29 @@ class TestUnmarkableHandlers:
         # Wrapping before registration stays allowed.
         require_auth(Controller().secret)
 
+    def test_wraps_wrapper_of_registered_handler_is_not_route_registered(self):
+        """The route-registered marker is a weak registry, not a function
+        attribute, so functools.wraps does NOT propagate it. A wrapper that
+        wraps a registered handler must not be falsely treated as registered
+        (which would make the decorator-order guard reject it spuriously)."""
+        import functools
+
+        app = Kinglet()
+
+        @app.get("/data", public=True)
+        async def data(request):
+            return {}
+
+        assert is_route_registered(data)
+
+        @functools.wraps(data)  # copies __dict__ - must NOT carry registration
+        async def wrapper(request):
+            return await data(request)
+
+        assert not is_route_registered(wrapper)
+        # Applying a security decorator to the wrapper must NOT falsely raise.
+        require_auth(wrapper)
+
 
 class TestEveryBuiltinDecoratorIsGuarded:
     """One red test per decorator if its guard call is ever removed."""

--- a/tests/test_route_policy.py
+++ b/tests/test_route_policy.py
@@ -172,6 +172,87 @@ class TestBuiltinDecoratorsSatisfyPolicy:
         assert status == 404  # dev blackhole in production
 
 
+class TestOriginalCustomDecoratorReversedBypass:
+    """Literal regression for the original High (commit 0f4a5e3): a CUSTOM auth
+    decorator applied ABOVE the route decorator used to register successfully
+    and let unauthenticated requests reach the handler with the custom wrapper
+    never invoked. Under default-deny it fails closed at registration; with
+    @security_decorator in the correct order the wrapper actually runs.
+
+    Mirrors the finding's exact PoC, including the @router.get form and a
+    call-log that proves the wrapper is/ isn't invoked.
+    """
+
+    @staticmethod
+    def _make_require_admin(call_log):
+        def require_admin(handler):
+            async def wrapped(request):
+                call_log.append("wrapper")
+                if request.header("x-admin-token") != "valid":
+                    return Response({"error": "forbidden"}, status=403)
+                return await handler(request)
+
+            return wrapped
+
+        return require_admin
+
+    def test_reversed_over_router_get_fails_closed(self):
+        call_log = []
+        require_admin = self._make_require_admin(call_log)
+        router = Router()
+
+        with pytest.raises(RuntimeError, match="security posture"):
+
+            @require_admin
+            @router.get("/admin")
+            async def admin(request):
+                return {"admin": "data"}
+
+        # The broken route never registered, and the wrapper never ran.
+        assert router.resolve("GET", "/admin")[0] is None
+        assert call_log == []
+
+    def test_reversed_over_app_get_fails_closed(self):
+        call_log = []
+        require_admin = self._make_require_admin(call_log)
+        app = Kinglet()
+
+        with pytest.raises(RuntimeError, match="security posture"):
+
+            @require_admin
+            @app.get("/admin")
+            async def admin(request):
+                return {"admin": "data"}
+
+        assert app.router.resolve("GET", "/admin")[0] is None
+        assert call_log == []
+
+    def test_correct_order_with_security_decorator_invokes_wrapper(self):
+        call_log = []
+        require_admin = security_decorator(self._make_require_admin(call_log))
+        app = Kinglet()
+
+        @app.get("/admin")
+        @require_admin
+        async def admin(request):
+            return {"admin": "data"}
+
+        client = TestClient(app)
+
+        # Unauthenticated: the custom wrapper RUNS and forbids (counterexample).
+        status, _, body = client.request("GET", "/admin")
+        assert status == 403
+        assert call_log == ["wrapper"]
+        assert "data" not in body
+
+        # Authenticated: wrapper runs and reaches the handler.
+        status, _, body = client.request(
+            "GET", "/admin", headers={"x-admin-token": "valid"}
+        )
+        assert status == 200
+        assert "data" in body
+
+
 class TestSecuredMarkerCannotBeLaundered:
     """Regression for the marker-laundering finding: an outer wrapper that uses
     functools.wraps and short-circuits (never calls the inner auth wrapper)

--- a/tests/test_route_policy.py
+++ b/tests/test_route_policy.py
@@ -12,6 +12,7 @@ conftest relaxation that the rest of the suite uses does NOT apply here.
 """
 
 import base64
+import functools
 import hashlib
 import hmac
 import json
@@ -169,6 +170,49 @@ class TestBuiltinDecoratorsSatisfyPolicy:
             "GET", "/debug"
         )
         assert status == 404  # dev blackhole in production
+
+
+class TestSecuredMarkerCannotBeLaundered:
+    """Regression for the marker-laundering finding: an outer wrapper that uses
+    functools.wraps and short-circuits (never calls the inner auth wrapper)
+    must NOT inherit the secured posture. The posture is tracked by object
+    identity, which functools.wraps does not copy."""
+
+    @staticmethod
+    def _short_circuit_wrapper(handler):
+        @functools.wraps(handler)  # copies __dict__ - must NOT carry the posture
+        async def wrapped(req):
+            return Response({"secret": "LEAKED", "auth_ran": False}, status=200)
+
+        return wrapped
+
+    def test_laundered_marker_fails_closed_at_registration(self):
+        app = Kinglet()
+        with pytest.raises(RuntimeError, match="security posture"):
+
+            @app.get("/secret")
+            @self._short_circuit_wrapper
+            @require_auth
+            async def secret(req):
+                return {"secret": "protected"}
+
+    def test_no_unauthenticated_response_is_served(self):
+        """Even if the route somehow registered, dispatch must never reach the
+        laundering wrapper. Pin it end-to-end via the opt-out, then prove the
+        enforcing app refuses to register it at all."""
+        app = Kinglet()
+        registered = True
+        try:
+
+            @app.get("/secret")
+            @self._short_circuit_wrapper
+            @require_auth
+            async def secret(req):
+                return {}
+        except RuntimeError:
+            registered = False
+        assert registered is False
+        assert app.router.resolve("GET", "/secret")[0] is None
 
 
 class TestSecurityDecorator:

--- a/tests/test_route_policy.py
+++ b/tests/test_route_policy.py
@@ -27,6 +27,7 @@ from kinglet import (
     Router,
     TestClient,
     is_secured,
+    mark_secured,
     require_dev,
     security_decorator,
 )
@@ -294,6 +295,35 @@ class TestSecuredMarkerCannotBeLaundered:
             registered = False
         assert registered is False
         assert app.router.resolve("GET", "/secret")[0] is None
+
+    def test_value_equal_callable_cannot_launder_marker(self):
+        """The secured registry is keyed by object identity, not value equality.
+        A distinct callable that merely compares equal to a marked one (e.g. a
+        callable class with value-based __eq__/__hash__) is NOT secured and a
+        route using it fails closed."""
+
+        class CallableHandler:
+            def __init__(self, name):
+                self.name = name
+
+            def __eq__(self, other):
+                return isinstance(other, CallableHandler) and self.name == other.name
+
+            def __hash__(self):
+                return hash(self.name)
+
+            async def __call__(self, request):
+                return {"secret": True}
+
+        marked = mark_secured(CallableHandler("admin"))
+        equal_but_distinct = CallableHandler("admin")
+        assert is_secured(marked)
+        assert marked == equal_but_distinct and marked is not equal_but_distinct
+        assert not is_secured(equal_but_distinct)
+
+        app = Kinglet()
+        with pytest.raises(RuntimeError, match="security posture"):
+            app.router.add_route("/x", equal_but_distinct, ["GET"])
 
 
 class TestSecurityDecorator:


### PR DESCRIPTION
## The finding (reproduced)

The 2.0 route policy marked routes "secured" via a `__kinglet_secured__` function attribute — stored in `__dict__` *specifically* so it propagated through `functools.wraps`. That propagation is the bug: an unrelated **outer** wrapper laundered the marker.

PoC, on a default app:
```python
def cache_or_maintenance(handler):
    @functools.wraps(handler)        # copies __dict__ → inherits __kinglet_secured__
    async def wrapped(req): return {"secret": "LEAKED"}   # never calls handler
    return wrapped

@app.get("/secret")
@cache_or_maintenance     # outer, short-circuits
@require_auth             # inner, marks secured
async def secret(req): ...
```
Registered without `public=True`; unauthenticated `GET /secret` → **200 with the secret**, `require_auth` never ran. Control route correctly 401s. High is fair — it's the framework giving false "secured" assurance, the exact class the policy exists to kill.

## Fix: track the posture by object identity, not a copyable attribute

- The secured marker is now membership in a `WeakSet`, keyed by **object identity**. `functools.wraps` copies `__dict__` but not registry identity, so an outer wrapper is a different, unmarked object → fails the policy **closed**.
- The one legitimate propagation — `wrap_exceptions`, the framework's auto-applied, *provably-transparent* wrapper (it always calls the inner handler) — re-marks explicitly. Mutation test confirms this re-mark is load-bearing for the normal `@app.get`/`@require_auth` path.
- Built-in decorators and `@security_decorator` already mark their own wrappers, so stacked auth and the auto-wrap path are unaffected.

## Blast radius (negligible, as expected)
Only an arbitrary user wrapper interposed *between* the route and the auth decorator now fails closed — and that case always could have short-circuited, so the framework (which can't verify it calls through) must reject it. The fix is to put the auth decorator outermost (the correct order anyway). Bonus: hand-forging `__kinglet_secured__` no longer bypasses either; `mark_secured()` remains the supported opt-in.

## Tests
- `TestSecuredMarkerCannotBeLaundered` pins the PoC fail-closed.
- Adversarial `a2`/`a4` flipped from laundering-as-feature to fail-closed (+ an `a2` companion showing auth-outermost is the fix).
- **1264 passed.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security decorator enforcement to prevent improper decorator composition from bypassing authentication checks. Invalid decorator stacking is now caught at route registration time (fail-closed behavior).
  * Fixed marker laundering vulnerability where security postures could be inherited through wrapper decorators that don't enforce actual authorization.

* **Tests**
  * Added comprehensive test coverage for security decorator bypass scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->