### PR TITLE
Fix unhashable-handler order-guard regression by unifying on identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,17 @@ For each route, do **one** of the following:
   unhashable callable handlers too). Bound-method handlers must be captured once
   (`h = obj.method`) and the same object reused, since each access is a new
   object under identity tracking.
+- **Residual order-guard limitation (by design).** The decorator-order guard
+  tracks by identity, so it cannot recognize a *fresh* `obj.method` access of a
+  registered bound method, and it cannot track a non-weakref-able handler at
+  all. Kinglet warns (`RoutePolicyWarning`) at registration in these cases. This
+  is **not** a default-config risk: under the default policy an unsecured route
+  is refused before it registers. It only carries residual risk when the policy
+  is bypassed for the route (`public=True`) or disabled (`enforce_route_policy=
+  False`) **and** a security decorator is applied in reversed order — there the
+  guard is the only check, and the warning is the signal. Teams that want these
+  to fail rather than warn should treat `RoutePolicyWarning` as an error in CI:
+  `warnings.filterwarnings("error", category=RoutePolicyWarning)`.
 - `Kinglet` now also exposes `head()` and `options()` route decorators (were
   previously only on `Router`).
 - The registration error names the offending handler and points at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,12 +83,15 @@ For each route, do **one** of the following:
 - Disabling the policy (`enforce_route_policy=False`) emits a
   `RoutePolicyWarning` so an intentional opt-out is not mistaken for one
   forgotten during migration.
-- The "secured" posture is tracked by **object identity** in an internal
+- The "secured" posture is tracked by **object identity** in an internal weak
   registry, set via `mark_secured()` / `@security_decorator`. There is no public
   `__kinglet_secured__` attribute: hand-setting that attribute does nothing
   (use `mark_secured()`), and it cannot be laundered onto an outer wrapper by
-  `functools.wraps`. The route-registered order guard uses a weak registry for
-  the same reason (no `functools.wraps` false positives).
+  `functools.wraps`. The route-registered order guard uses the **same** identity
+  registry mechanism (no `functools.wraps` false positives, and it tracks
+  unhashable callable handlers too). Bound-method handlers must be captured once
+  (`h = obj.method`) and the same object reused, since each access is a new
+  object under identity tracking.
 - `Kinglet` now also exposes `head()` and `options()` route decorators (were
   previously only on `Router`).
 - The registration error names the offending handler and points at

--- a/kinglet/decorators.py
+++ b/kinglet/decorators.py
@@ -12,6 +12,24 @@ from collections.abc import Callable
 from .exceptions import GeoRestrictedError, HTTPError
 from .http import Response
 
+
+class RoutePolicyWarning(UserWarning):
+    """Signals a route-security situation a developer should know about.
+
+    Emitted when: the default-deny policy is disabled (``enforce_route_policy=
+    False``); a raw bound method is registered as a handler (identity tracking
+    cannot match a fresh ``obj.method`` access); or a handler is not weakref-able
+    and cannot be tracked by the decorator-order guard.
+
+    These are warnings, not errors, because the situations have legitimate uses
+    and the default-deny policy remains the real backstop. Teams that want them
+    to fail can escalate in CI, e.g.::
+
+        warnings.filterwarnings("error", category=RoutePolicyWarning)
+        # or: python -W error::kinglet.decorators.RoutePolicyWarning
+    """
+
+
 # Registry of callables registered to a route, used by the decorator-order
 # guard. Keyed by id() and verified with `is` - the SAME identity mechanism as
 # _SECURED_HANDLERS below (one model, not two). Identity is the right match
@@ -45,7 +63,7 @@ def mark_route_registered(handler: Callable) -> Callable:
             "Capture it once (handler = obj.method) and reuse that reference, or "
             "use a plain function handler.",
             RoutePolicyWarning,
-            stacklevel=2,
+            stacklevel=4,
         )
     try:
         _ROUTE_REGISTERED_HANDLERS[id(handler)] = handler
@@ -57,7 +75,7 @@ def mark_route_registered(handler: Callable) -> Callable:
             f"mark_route_registered: {handler!r} is not weakref-able; the "
             f"decorator-order guard is skipped for this callable.",
             RoutePolicyWarning,
-            stacklevel=2,
+            stacklevel=4,
         )
     return handler
 
@@ -98,15 +116,6 @@ def reject_if_route_registered(handler: Callable, decorator_name: str) -> None:
 # decorator bypass fail closed *by default*, without any module/global name
 # lookup: at registration time the handler is simply inspected for the marker.
 # ---------------------------------------------------------------------------
-
-
-class RoutePolicyWarning(UserWarning):
-    """Emitted when the default-deny route policy is disabled.
-
-    Disabling enforcement removes a framework-level guard against accidentally
-    unprotected routes; the warning leaves an audit signal so an intentional
-    opt-out is not mistaken for one forgotten during migration.
-    """
 
 
 # Registry of callables that a recognized access-control decorator actually

--- a/kinglet/decorators.py
+++ b/kinglet/decorators.py
@@ -47,7 +47,11 @@ def mark_route_registered(handler: Callable) -> Callable:
 
 def is_route_registered(handler: Callable) -> bool:
     """Return True if this exact callable was already registered with a route."""
-    return _ROUTE_REGISTERED_HANDLERS.get(id(handler)) is handler
+    # `handler is not None` guards the degenerate case: get() returns None when
+    # the id is absent, and `None is None` would otherwise report True.
+    return (
+        handler is not None and _ROUTE_REGISTERED_HANDLERS.get(id(handler)) is handler
+    )
 
 
 def reject_if_route_registered(handler: Callable, decorator_name: str) -> None:
@@ -152,7 +156,9 @@ def mark_secured(handler: Callable) -> Callable:
 
 def is_secured(handler: Callable) -> bool:
     """Return True if this exact callable was produced by a recognized decorator."""
-    return _SECURED_HANDLERS.get(id(handler)) is handler
+    # `handler is not None` guards the degenerate case (get() default is None,
+    # so `None is None` would otherwise report True for a None handler).
+    return handler is not None and _SECURED_HANDLERS.get(id(handler)) is handler
 
 
 def security_decorator(decorator_fn: Callable) -> Callable:

--- a/kinglet/decorators.py
+++ b/kinglet/decorators.py
@@ -3,6 +3,7 @@ Kinglet Decorators and Utility Functions
 """
 
 import functools
+import inspect
 import json
 import warnings
 import weakref
@@ -30,6 +31,22 @@ def mark_route_registered(handler: Callable) -> Callable:
     decorator-order guard recognizes exactly the registered callable without
     functools.wraps propagating the mark to outer wrappers.
     """
+    if inspect.ismethod(handler):
+        # A *raw* bound method only reaches here in a footgun-prone config: the
+        # default policy rejects an unsecured bound-method route, and a correctly
+        # secured one registers the (function) security wrapper, not the method.
+        # Bound methods are recreated on each attribute access, so the identity
+        # guard only recognizes the exact object registered. Warn eagerly rather
+        # than silently miss a reversed-order decorator on a fresh access.
+        warnings.warn(
+            "A bound method was registered as a route handler. Bound methods are "
+            "recreated on each attribute access and tracked by identity, so the "
+            "decorator-order guard only recognizes the exact object registered. "
+            "Capture it once (handler = obj.method) and reuse that reference, or "
+            "use a plain function handler.",
+            RoutePolicyWarning,
+            stacklevel=2,
+        )
     try:
         _ROUTE_REGISTERED_HANDLERS[id(handler)] = handler
     except TypeError:

--- a/kinglet/decorators.py
+++ b/kinglet/decorators.py
@@ -12,34 +12,32 @@ from .exceptions import GeoRestrictedError, HTTPError
 from .http import Response
 
 # Registry of callables registered to a route, used by the decorator-order
-# guard. A WeakSet (value-equality membership) so a fresh access of a registered
-# bound method still matches via (instance, function) equality. Crucially,
-# WeakSet membership is NOT copied by functools.wraps - unlike a function
-# attribute, which wraps copies into outer wrappers and which previously made
-# the order guard reject a wrapper that merely inherited the copied attribute.
-#
-# Contrast _SECURED_HANDLERS, which must use STRICT identity to stop value-
-# equality laundering of the auth posture. Here value-equality is fine: it only
-# ever over-triggers the fail-loud order guard (never a bypass), so matching a
-# fresh bound-method access is the desired behaviour.
-_ROUTE_REGISTERED_HANDLERS: weakref.WeakSet = weakref.WeakSet()
+# guard. Keyed by id() and verified with `is` - the SAME identity mechanism as
+# _SECURED_HANDLERS below (one model, not two). Identity is the right match
+# here: id() works for any object (including unhashable callables, which a set
+# cannot hold), and registry membership is not copied by functools.wraps, so
+# wrapping a registered handler does not falsely mark the wrapper. Bound methods
+# are recreated on each attribute access, so - exactly as for mark_secured -
+# capture the reference once and pass the same object to registration and to any
+# later check.
+_ROUTE_REGISTERED_HANDLERS: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
 
 
 def mark_route_registered(handler: Callable) -> Callable:
     """Mark a callable as registered with a route.
 
-    Membership is held weakly and is not propagated by functools.wraps, so the
-    decorator-order guard recognizes exactly the registered callables (and fresh
-    accesses of registered bound methods) without false positives from wrapping.
+    Tracked by object identity (held weakly), not a function attribute, so the
+    decorator-order guard recognizes exactly the registered callable without
+    functools.wraps propagating the mark to outer wrappers.
     """
     try:
-        _ROUTE_REGISTERED_HANDLERS.add(handler)
+        _ROUTE_REGISTERED_HANDLERS[id(handler)] = handler
     except TypeError:
-        # Not weakref-able / not hashable: cannot be tracked, so the
-        # decorator-order guard is skipped for this callable. Surface it for
-        # consistency with mark_secured (still fail-loud only - never a bypass).
+        # Not weakref-able: cannot be tracked, so the decorator-order guard is
+        # skipped for this callable. Surface it (still fail-loud only - never a
+        # bypass; the default-deny route policy remains the real backstop).
         warnings.warn(
-            f"mark_route_registered: {handler!r} is not trackable; the "
+            f"mark_route_registered: {handler!r} is not weakref-able; the "
             f"decorator-order guard is skipped for this callable.",
             RoutePolicyWarning,
             stacklevel=2,
@@ -48,11 +46,8 @@ def mark_route_registered(handler: Callable) -> Callable:
 
 
 def is_route_registered(handler: Callable) -> bool:
-    """Return True if the callable was already registered with a route."""
-    try:
-        return handler in _ROUTE_REGISTERED_HANDLERS
-    except TypeError:  # unhashable callable
-        return False
+    """Return True if this exact callable was already registered with a route."""
+    return _ROUTE_REGISTERED_HANDLERS.get(id(handler)) is handler
 
 
 def reject_if_route_registered(handler: Callable, decorator_name: str) -> None:
@@ -109,7 +104,8 @@ class RoutePolicyWarning(UserWarning):
 # Values are held weakly so entries die with the callable; the ``is`` check also
 # guards against id reuse after garbage collection. The check runs synchronously
 # at registration while the route holds a strong reference, so liveness is never
-# a concern at check time.
+# a concern at check time. (``_ROUTE_REGISTERED_HANDLERS`` above uses the exact
+# same mechanism - one identity model for both markers.)
 _SECURED_HANDLERS: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
 
 

--- a/tests/test_route_binding_security.py
+++ b/tests/test_route_binding_security.py
@@ -288,7 +288,38 @@ class TestUnmarkableHandlers:
                 return {}
 
             router.add_route("/fn", fn, ["GET"], public=True)
-        assert not caught
+        # Only assert the absence of OUR warning - an unrelated warning from the
+        # environment must not fail this test.
+        assert not any(issubclass(c.category, RoutePolicyWarning) for c in caught)
+
+    def test_non_weakref_able_handler_warns_and_is_not_tracked(self):
+        """A non-weakref-able callable (``__slots__`` without ``__weakref__``,
+        and unhashable) cannot be tracked at all: the registry skips it and a
+        RoutePolicyWarning is emitted. The order guard then cannot fire for it,
+        so under enforce_route_policy=False (no default-deny backstop) a reversed
+        security decorator is NOT caught. This pins that documented limitation;
+        teams that want it to fail should escalate RoutePolicyWarning in CI."""
+        import warnings
+
+        class NonWeakrefHandler:
+            __slots__ = ()  # no __weakref__ slot → not weakref-able
+            __hash__ = None  # also unhashable
+
+            async def __call__(self, request):
+                return {"secret": True}
+
+        handler = NonWeakrefHandler()
+        # enforce off so the policy backstop does not reject it first.
+        app = Kinglet(enforce_route_policy=False)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            app.router.add_route("/x", handler, ["GET"])
+        assert any(issubclass(c.category, RoutePolicyWarning) for c in caught)
+
+        # Untrackable → guard cannot fire (documented limitation, not a default
+        # bypass: this only matters with the policy disabled).
+        assert not is_route_registered(handler)
+        require_auth(handler)  # does not raise - the guard is blind here
 
     def test_unhashable_callable_handler_is_tracked(self):
         """Regression: an UNHASHABLE callable object (defines __eq__ without

--- a/tests/test_route_binding_security.py
+++ b/tests/test_route_binding_security.py
@@ -228,16 +228,31 @@ class TestUnmarkableHandlers:
 
         controller = Controller()
         router = Router()
-        # Bound methods reject setattr; the weak registry must catch them.
-        # public=True only satisfies the route policy; the route-registered
-        # marker (what this test exercises) is independent of it.
-        router.add_route("/secret", controller.secret, ["GET"], public=True)
+        # Bound methods are recreated on each access and are identity-tracked
+        # (same model as mark_secured), so capture the reference once and use the
+        # SAME object for registration and the guard check.
+        handler = controller.secret
+        router.add_route("/secret", handler, ["GET"], public=True)
 
-        # Every `controller.secret` access creates a fresh bound-method object;
-        # it must still be recognised via (instance, function) equality.
-        assert is_route_registered(controller.secret)
+        assert is_route_registered(handler)
         with pytest.raises(RuntimeError, match="require_auth"):
-            require_auth(controller.secret)
+            require_auth(handler)
+
+    def test_fresh_bound_method_access_is_not_matched(self):
+        """Identity tracking: a FRESH `obj.method` access is a different object
+        and is not recognized - bound methods must be captured once (consistent
+        with the mark_secured rule). This is a fail-loud limitation of the order
+        guard, never a bypass (the default-deny policy is the real backstop)."""
+
+        class Controller:
+            async def secret(self, request):
+                return {"secret": True}
+
+        controller = Controller()
+        router = Router()
+        router.add_route("/secret", controller.secret, ["GET"], public=True)
+        # A different access object → not matched.
+        assert not is_route_registered(controller.secret)
 
     def test_unregistered_bound_method_is_not_flagged(self):
         class Controller:
@@ -247,6 +262,29 @@ class TestUnmarkableHandlers:
         assert not is_route_registered(Controller().secret)
         # Wrapping before registration stays allowed.
         require_auth(Controller().secret)
+
+    def test_unhashable_callable_handler_is_tracked(self):
+        """Regression: an UNHASHABLE callable object (defines __eq__ without
+        __hash__) cannot live in a set, but the identity registry tracks it by
+        id(), so the decorator-order guard still fires. A WeakSet-only registry
+        silently skipped these, letting a late security decorator pass."""
+
+        class UnhashableHandler:
+            def __eq__(self, other):
+                return isinstance(other, UnhashableHandler)
+
+            __hash__ = None  # unhashable, but weakref-able
+
+            async def __call__(self, request):
+                return {"secret": True}
+
+        handler = UnhashableHandler()
+        router = Router()
+        router.add_route("/x", handler, ["GET"], public=True)
+
+        assert is_route_registered(handler)
+        with pytest.raises(RuntimeError, match="require_auth"):
+            require_auth(handler)
 
     def test_wraps_wrapper_of_registered_handler_is_not_route_registered(self):
         """The route-registered marker is a weak registry, not a function

--- a/tests/test_route_binding_security.py
+++ b/tests/test_route_binding_security.py
@@ -19,6 +19,7 @@ import pytest
 from kinglet import (
     Kinglet,
     Response,
+    RoutePolicyWarning,
     Router,
     TestClient,
     geo_restrict,
@@ -262,6 +263,32 @@ class TestUnmarkableHandlers:
         assert not is_route_registered(Controller().secret)
         # Wrapping before registration stays allowed.
         require_auth(Controller().secret)
+
+    def test_raw_bound_method_registration_warns_eagerly(self):
+        """Eager amelioration of the bound-method footgun: registering a RAW
+        bound method as a handler (which only happens in public=True / enforce-
+        off configs) warns about the identity-tracking limitation. A plain
+        function handler does not warn."""
+        import warnings
+
+        class Controller:
+            async def handle(self, request):
+                return {}
+
+        router = Router()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            router.add_route("/bm", Controller().handle, ["GET"], public=True)
+        assert any(issubclass(c.category, RoutePolicyWarning) for c in caught)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            async def fn(request):
+                return {}
+
+            router.add_route("/fn", fn, ["GET"], public=True)
+        assert not caught
 
     def test_unhashable_callable_handler_is_tracked(self):
         """Regression: an UNHASHABLE callable object (defines __eq__ without

--- a/tests/test_route_policy.py
+++ b/tests/test_route_policy.py
@@ -26,6 +26,7 @@ from kinglet import (
     RoutePolicyWarning,
     Router,
     TestClient,
+    is_route_registered,
     is_secured,
     mark_secured,
     require_dev,
@@ -171,6 +172,18 @@ class TestBuiltinDecoratorsSatisfyPolicy:
             "GET", "/debug"
         )
         assert status == 404  # dev blackhole in production
+
+
+class TestRegistryDegenerateInputs:
+    """The identity registries use ``get(id(h)) is h``; get() returns None when
+    the id is absent, so a None handler must not read back as registered/secured
+    (None is None would otherwise be True)."""
+
+    def test_none_is_not_secured(self):
+        assert is_secured(None) is False
+
+    def test_none_is_not_route_registered(self):
+        assert is_route_registered(None) is False
 
 
 class TestOriginalCustomDecoratorReversedBypass:


### PR DESCRIPTION
Medium finding: switching the route-registered guard to a WeakSet (S2/R3) regressed unhashable callable handlers - a WeakSet needs hashable elements, so a callable object that defines __eq__ without __hash__ was silently skipped by mark_route_registered. The decorator-order guard then did not fire when a security decorator was applied to it after registration; with public=True (or enforce_route_policy=False) an unauthenticated request reached the original handler. Reproduced: 200 with protected data.

Rather than add a second registry (id fallback) and keep two matching rules, we unify: _ROUTE_REGISTERED_HANDLERS is now the SAME id-keyed WeakValueDictionary identity mechanism as _SECURED_HANDLERS. id() works for any object including unhashable ones, the membership is not copied by functools.wraps (preserving the S2 fix), and the asymmetry that R3 flagged is gone - one identity model for both markers, fewer internal surfaces to maintain.

Cost: bound methods are now identity-tracked everywhere (capture obj.method once and reuse the same object), consistent with the mark_secured rule already documented. The only behaviour lost is matching a FRESH bound-method access in the order guard - a contrived manual pattern, fail-loud only, never a bypass (default-deny policy is the backstop).

Tests: unhashable handler is tracked and guarded (regression pin); fresh bound-method access is not matched (intentional, pinned); existing bound-method test updated to capture-once. 1274 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded changelog guidance on how route “secured” posture is tracked, including bound-method identity behavior and the need to reuse the same handler reference.

* **Improvements**
  * Strengthened route-decorator order-guard identity tracking using an identity-based registry, with explicit handling for unhashable and non-weakref-able callables (plus clearer warnings for bound methods).
  * Ensured `None` handlers are never treated as secured or route-registered.

* **Tests**
  * Added regression coverage for bound-method identity limitations, warning behavior, and degenerate `None`/unhashable handler cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->