### PR TITLE
Close bound-method order-guard bypass (High) via logical-identity keying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@ For each route, do **one** of the following:
   (use `mark_secured()`), and it cannot be laundered onto an outer wrapper by
   `functools.wraps`. The route-registered order guard uses a single weak
   registry keyed by **logical identity**: `id()` for ordinary callables, and
-  `(instance, function)` for bound methods, so a *fresh* `obj.method` access of
+  `(id(instance), id(function))` for bound methods, so a *fresh* `obj.method` access of
   a registered bound method is still recognized and the reversed-order guard
   still fires. It also tracks unhashable callable handlers, and is not copied by
   `functools.wraps`. (The secured marker deliberately stays strict-`id` only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,21 +87,21 @@ For each route, do **one** of the following:
   registry, set via `mark_secured()` / `@security_decorator`. There is no public
   `__kinglet_secured__` attribute: hand-setting that attribute does nothing
   (use `mark_secured()`), and it cannot be laundered onto an outer wrapper by
-  `functools.wraps`. The route-registered order guard uses the **same** identity
-  registry mechanism (no `functools.wraps` false positives, and it tracks
-  unhashable callable handlers too). Bound-method handlers must be captured once
-  (`h = obj.method`) and the same object reused, since each access is a new
-  object under identity tracking.
-- **Residual order-guard limitation (by design).** The decorator-order guard
-  tracks by identity, so it cannot recognize a *fresh* `obj.method` access of a
-  registered bound method, and it cannot track a non-weakref-able handler at
-  all. Kinglet warns (`RoutePolicyWarning`) at registration in these cases. This
-  is **not** a default-config risk: under the default policy an unsecured route
-  is refused before it registers. It only carries residual risk when the policy
-  is bypassed for the route (`public=True`) or disabled (`enforce_route_policy=
-  False`) **and** a security decorator is applied in reversed order — there the
-  guard is the only check, and the warning is the signal. Teams that want these
-  to fail rather than warn should treat `RoutePolicyWarning` as an error in CI:
+  `functools.wraps`. The route-registered order guard uses a single weak
+  registry keyed by **logical identity**: `id()` for ordinary callables, and
+  `(instance, function)` for bound methods, so a *fresh* `obj.method` access of
+  a registered bound method is still recognized and the reversed-order guard
+  still fires. It also tracks unhashable callable handlers, and is not copied by
+  `functools.wraps`. (The secured marker deliberately stays strict-`id` only:
+  logical/value equality there would let a value-equal callable launder the auth
+  posture.)
+- **Residual order-guard limitation (by design).** A handler that is not
+  weakref-able (e.g. `__slots__` without `__weakref__`) cannot be tracked at
+  all; Kinglet warns (`RoutePolicyWarning`) at registration. This is **not** a
+  default-config risk (the default policy refuses an unsecured route before it
+  registers); it only matters under `enforce_route_policy=False` with a reversed
+  security decorator. Teams that want such cases to fail rather than warn should
+  treat `RoutePolicyWarning` as an error in CI:
   `warnings.filterwarnings("error", category=RoutePolicyWarning)`.
 - `Kinglet` now also exposes `head()` and `options()` route decorators (were
   previously only on `Router`).

--- a/kinglet/decorators.py
+++ b/kinglet/decorators.py
@@ -16,10 +16,9 @@ from .http import Response
 class RoutePolicyWarning(UserWarning):
     """Signals a route-security situation a developer should know about.
 
-    Emitted when: the default-deny policy is disabled (``enforce_route_policy=
-    False``); a raw bound method is registered as a handler (identity tracking
-    cannot match a fresh ``obj.method`` access); or a handler is not weakref-able
-    and cannot be tracked by the decorator-order guard.
+    Emitted when the default-deny policy is disabled (``enforce_route_policy=
+    False``), or when a handler is not weakref-able and so cannot be tracked by
+    the decorator-order guard.
 
     These are warnings, not errors, because the situations have legitimate uses
     and the default-deny policy remains the real backstop. Teams that want them
@@ -31,42 +30,45 @@ class RoutePolicyWarning(UserWarning):
 
 
 # Registry of callables registered to a route, used by the decorator-order
-# guard. Keyed by id() and verified with `is` - the SAME identity mechanism as
-# _SECURED_HANDLERS below (one model, not two). Identity is the right match
-# here: id() works for any object (including unhashable callables, which a set
-# cannot hold), and registry membership is not copied by functools.wraps, so
-# wrapping a registered handler does not falsely mark the wrapper. Bound methods
-# are recreated on each attribute access, so - exactly as for mark_secured -
-# capture the reference once and pass the same object to registration and to any
-# later check.
+# guard. Keyed by LOGICAL identity and verified weakly: a bound method is keyed
+# by ``(instance, function)`` so a fresh ``obj.method`` access (Python builds a
+# new bound-method object every time) maps to the same entry and the guard still
+# fires; every other callable is keyed by ``id()`` and verified with ``is``.
+# Logical keying works for any object (including unhashable callables, which a
+# set cannot hold), and is not copied by functools.wraps, so wrapping a
+# registered handler does not falsely mark the wrapper.
+#
+# Value-equality here is safe: this registry only ever feeds the fail-loud
+# decorator-order guard, so an over-match can only raise spuriously, never let
+# an unprotected route through. Contrast ``_SECURED_HANDLERS`` below, which must
+# use STRICT identity (no logical keying) so a value-equal callable cannot
+# launder the auth posture.
 _ROUTE_REGISTERED_HANDLERS: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
+
+
+def _route_registry_key(handler: Callable):
+    """Logical-identity key for the route-registered registry.
+
+    Bound methods are recreated on each attribute access, so key them by
+    ``(id(instance), id(function))`` - stable across fresh accesses. While the
+    route holds the registered bound method, it (and therefore its instance)
+    stays alive, so neither id is reused. Everything else is keyed by ``id()``.
+    """
+    if inspect.ismethod(handler):
+        return (id(handler.__self__), id(handler.__func__))
+    return id(handler)
 
 
 def mark_route_registered(handler: Callable) -> Callable:
     """Mark a callable as registered with a route.
 
-    Tracked by object identity (held weakly), not a function attribute, so the
-    decorator-order guard recognizes exactly the registered callable without
-    functools.wraps propagating the mark to outer wrappers.
+    Tracked by logical identity in a weak registry (not a function attribute),
+    so the decorator-order guard recognizes the registered callable - including
+    a fresh access of a registered bound method - without functools.wraps
+    propagating the mark to outer wrappers.
     """
-    if inspect.ismethod(handler):
-        # A *raw* bound method only reaches here in a footgun-prone config: the
-        # default policy rejects an unsecured bound-method route, and a correctly
-        # secured one registers the (function) security wrapper, not the method.
-        # Bound methods are recreated on each attribute access, so the identity
-        # guard only recognizes the exact object registered. Warn eagerly rather
-        # than silently miss a reversed-order decorator on a fresh access.
-        warnings.warn(
-            "A bound method was registered as a route handler. Bound methods are "
-            "recreated on each attribute access and tracked by identity, so the "
-            "decorator-order guard only recognizes the exact object registered. "
-            "Capture it once (handler = obj.method) and reuse that reference, or "
-            "use a plain function handler.",
-            RoutePolicyWarning,
-            stacklevel=4,
-        )
     try:
-        _ROUTE_REGISTERED_HANDLERS[id(handler)] = handler
+        _ROUTE_REGISTERED_HANDLERS[_route_registry_key(handler)] = handler
     except TypeError:
         # Not weakref-able: cannot be tracked, so the decorator-order guard is
         # skipped for this callable. Surface it (still fail-loud only - never a
@@ -81,12 +83,16 @@ def mark_route_registered(handler: Callable) -> Callable:
 
 
 def is_route_registered(handler: Callable) -> bool:
-    """Return True if this exact callable was already registered with a route."""
-    # `handler is not None` guards the degenerate case: get() returns None when
-    # the id is absent, and `None is None` would otherwise report True.
-    return (
-        handler is not None and _ROUTE_REGISTERED_HANDLERS.get(id(handler)) is handler
-    )
+    """Return True if this callable (or a fresh access of it) was registered."""
+    if handler is None:
+        return False
+    stored = _ROUTE_REGISTERED_HANDLERS.get(_route_registry_key(handler))
+    if inspect.ismethod(handler):
+        # Logical match: a live entry under the (instance, function) key is the
+        # same logical method, even if this is a different bound-method object.
+        return stored is not None
+    # Strict identity for everything else (guards id reuse after GC).
+    return stored is handler
 
 
 def reject_if_route_registered(handler: Callable, decorator_name: str) -> None:
@@ -134,8 +140,9 @@ def reject_if_route_registered(handler: Callable, decorator_name: str) -> None:
 # Values are held weakly so entries die with the callable; the ``is`` check also
 # guards against id reuse after garbage collection. The check runs synchronously
 # at registration while the route holds a strong reference, so liveness is never
-# a concern at check time. (``_ROUTE_REGISTERED_HANDLERS`` above uses the exact
-# same mechanism - one identity model for both markers.)
+# a concern at check time. (``_ROUTE_REGISTERED_HANDLERS`` above uses the same
+# weak-registry storage but keys bound methods by logical identity; the secured
+# marker must NOT - strict identity is what stops value-equality laundering.)
 _SECURED_HANDLERS: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
 
 

--- a/kinglet/decorators.py
+++ b/kinglet/decorators.py
@@ -46,17 +46,18 @@ class RoutePolicyWarning(UserWarning):
 _ROUTE_REGISTERED_HANDLERS: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
 
 
-def _route_registry_key(handler: Callable):
-    """Logical-identity key for the route-registered registry.
+def _route_registry_key(handler: Callable) -> tuple[object, bool]:
+    """Return ``(registry_key, is_bound_method)`` for a handler.
 
     Bound methods are recreated on each attribute access, so key them by
     ``(id(instance), id(function))`` - stable across fresh accesses. While the
     route holds the registered bound method, it (and therefore its instance)
     stays alive, so neither id is reused. Everything else is keyed by ``id()``.
+    The ``is_bound_method`` flag is returned so callers compute it once.
     """
     if inspect.ismethod(handler):
-        return (id(handler.__self__), id(handler.__func__))
-    return id(handler)
+        return (id(handler.__self__), id(handler.__func__)), True
+    return id(handler), False
 
 
 def mark_route_registered(handler: Callable) -> Callable:
@@ -67,8 +68,9 @@ def mark_route_registered(handler: Callable) -> Callable:
     a fresh access of a registered bound method - without functools.wraps
     propagating the mark to outer wrappers.
     """
+    key, _ = _route_registry_key(handler)
     try:
-        _ROUTE_REGISTERED_HANDLERS[_route_registry_key(handler)] = handler
+        _ROUTE_REGISTERED_HANDLERS[key] = handler
     except TypeError:
         # Not weakref-able: cannot be tracked, so the decorator-order guard is
         # skipped for this callable. Surface it (still fail-loud only - never a
@@ -86,8 +88,9 @@ def is_route_registered(handler: Callable) -> bool:
     """Return True if this callable (or a fresh access of it) was registered."""
     if handler is None:
         return False
-    stored = _ROUTE_REGISTERED_HANDLERS.get(_route_registry_key(handler))
-    if inspect.ismethod(handler):
+    key, is_method = _route_registry_key(handler)
+    stored = _ROUTE_REGISTERED_HANDLERS.get(key)
+    if is_method:
         # Logical match: a live entry under the (instance, function) key is the
         # same logical method, even if this is a different bound-method object.
         return stored is not None
@@ -143,6 +146,10 @@ def reject_if_route_registered(handler: Callable, decorator_name: str) -> None:
 # a concern at check time. (``_ROUTE_REGISTERED_HANDLERS`` above uses the same
 # weak-registry storage but keys bound methods by logical identity; the secured
 # marker must NOT - strict identity is what stops value-equality laundering.)
+#
+# MUST NOT use logical / value keying (unlike _ROUTE_REGISTERED_HANDLERS): a
+# value-equal callable that did not pass through a recognized access decorator
+# must never satisfy is_secured(), or it would launder the auth posture.
 _SECURED_HANDLERS: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
 
 

--- a/kinglet/decorators.py
+++ b/kinglet/decorators.py
@@ -55,6 +55,10 @@ def _route_registry_key(handler: Callable) -> tuple[object, bool]:
     stays alive, so neither id is reused. Everything else is keyed by ``id()``.
     The ``is_bound_method`` flag is returned so callers compute it once.
     """
+    # inspect.ismethod() is True ONLY for Python bound methods (types.MethodType),
+    # which always expose __func__/__self__ - so the accesses below cannot raise
+    # AttributeError. Built-in / C methods are builtin_function_or_method (ismethod
+    # is False) and fall to the id() path; they are not valid async handlers anyway.
     if inspect.ismethod(handler):
         return (id(handler.__self__), id(handler.__func__)), True
     return id(handler), False

--- a/tests/test_route_binding_security.py
+++ b/tests/test_route_binding_security.py
@@ -229,68 +229,56 @@ class TestUnmarkableHandlers:
 
         controller = Controller()
         router = Router()
-        # Bound methods are recreated on each access and are identity-tracked
-        # (same model as mark_secured), so capture the reference once and use the
-        # SAME object for registration and the guard check.
-        handler = controller.secret
-        router.add_route("/secret", handler, ["GET"], public=True)
+        router.add_route("/secret", controller.secret, ["GET"], public=True)
 
-        assert is_route_registered(handler)
+        # A FRESH `controller.secret` access is a different bound-method object,
+        # but the registry keys bound methods by (instance, function), so the
+        # guard still recognizes it.
+        assert is_route_registered(controller.secret)
         with pytest.raises(RuntimeError, match="require_auth"):
-            require_auth(handler)
+            require_auth(controller.secret)
 
-    def test_fresh_bound_method_access_is_not_matched(self):
-        """Identity tracking: a FRESH `obj.method` access is a different object
-        and is not recognized - bound methods must be captured once (consistent
-        with the mark_secured rule). This is a fail-loud limitation of the order
-        guard, never a bypass (the default-deny policy is the real backstop)."""
+    def test_fresh_bound_method_reversed_decoration_is_caught(self):
+        """The bound-method order-guard High: registering a raw bound method and
+        then applying a security decorator to a FRESH access of it must raise -
+        the route would otherwise keep dispatching the unauthenticated handler.
+        Logical (instance, function) keying catches the fresh access."""
 
         class Controller:
             async def secret(self, request):
-                return {"secret": True}
+                return {"secret": "DATA"}
 
+        app = Kinglet()
         controller = Controller()
-        router = Router()
-        router.add_route("/secret", controller.secret, ["GET"], public=True)
-        # A different access object → not matched.
-        assert not is_route_registered(controller.secret)
+        app.router.add_route("/secret", controller.secret, ["GET"], public=True)
+
+        # Fresh access != the registered object, but same logical method.
+        with pytest.raises(RuntimeError, match="require_auth"):
+            require_auth(controller.secret)
 
     def test_unregistered_bound_method_is_not_flagged(self):
         class Controller:
             async def secret(self, request):
                 return {"secret": True}
 
+        # A different instance's method was never registered.
         assert not is_route_registered(Controller().secret)
         # Wrapping before registration stays allowed.
         require_auth(Controller().secret)
 
-    def test_raw_bound_method_registration_warns_eagerly(self):
-        """Eager amelioration of the bound-method footgun: registering a RAW
-        bound method as a handler (which only happens in public=True / enforce-
-        off configs) warns about the identity-tracking limitation. A plain
-        function handler does not warn."""
-        import warnings
+    def test_other_instance_same_method_is_not_matched(self):
+        """Logical keying is (instance, function): a different INSTANCE of the
+        same class is a different logical method and must not match."""
 
         class Controller:
-            async def handle(self, request):
-                return {}
+            async def secret(self, request):
+                return {"secret": True}
 
+        a, b = Controller(), Controller()
         router = Router()
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            router.add_route("/bm", Controller().handle, ["GET"], public=True)
-        assert any(issubclass(c.category, RoutePolicyWarning) for c in caught)
-
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-
-            async def fn(request):
-                return {}
-
-            router.add_route("/fn", fn, ["GET"], public=True)
-        # Only assert the absence of OUR warning - an unrelated warning from the
-        # environment must not fail this test.
-        assert not any(issubclass(c.category, RoutePolicyWarning) for c in caught)
+        router.add_route("/secret", a.secret, ["GET"], public=True)
+        assert is_route_registered(a.secret)
+        assert not is_route_registered(b.secret)  # different instance
 
     def test_non_weakref_able_handler_warns_and_is_not_tracked(self):
         """A non-weakref-able callable (``__slots__`` without ``__weakref__``,

--- a/tests/test_route_binding_security.py
+++ b/tests/test_route_binding_security.py
@@ -222,7 +222,11 @@ class TestNoHandlerRebinding:
 class TestUnmarkableHandlers:
     """Callables that cannot carry attributes must still trip the guard."""
 
-    def test_route_registered_bound_method_is_guarded(self):
+    def test_fresh_bound_method_access_matches_registry_predicate(self):
+        """Predicate level: after registering a bound method, a FRESH
+        `controller.secret` access (a different bound-method object, same
+        (instance, function)) reads back as route-registered."""
+
         class Controller:
             async def secret(self, request):
                 return {"secret": True}
@@ -231,18 +235,13 @@ class TestUnmarkableHandlers:
         router = Router()
         router.add_route("/secret", controller.secret, ["GET"], public=True)
 
-        # A FRESH `controller.secret` access is a different bound-method object,
-        # but the registry keys bound methods by (instance, function), so the
-        # guard still recognizes it.
-        assert is_route_registered(controller.secret)
-        with pytest.raises(RuntimeError, match="require_auth"):
-            require_auth(controller.secret)
+        assert is_route_registered(controller.secret)  # fresh access
 
     def test_fresh_bound_method_reversed_decoration_is_caught(self):
-        """The bound-method order-guard High: registering a raw bound method and
-        then applying a security decorator to a FRESH access of it must raise -
-        the route would otherwise keep dispatching the unauthenticated handler.
-        Logical (instance, function) keying catches the fresh access."""
+        """The bound-method order-guard High, end to end: registering a raw bound
+        method and then applying a security decorator to a FRESH access of it
+        must raise - the route would otherwise keep dispatching the original
+        unauthenticated handler. Logical (instance, function) keying catches it."""
 
         class Controller:
             async def secret(self, request):
@@ -255,6 +254,25 @@ class TestUnmarkableHandlers:
         # Fresh access != the registered object, but same logical method.
         with pytest.raises(RuntimeError, match="require_auth"):
             require_auth(controller.secret)
+
+    def test_registered_bound_method_entry_removed_after_route_drop(self):
+        """Negative GC: once the route (the only strong ref to the registered
+        bound method) is dropped, the weak entry disappears - no stale positive
+        from is_route_registered for a deregistered handler."""
+        import gc
+
+        class Controller:
+            async def handle(self, request):
+                return {}
+
+        router = Router()
+        controller = Controller()
+        router.add_route("/bm", controller.handle, ["GET"], public=True)
+        assert is_route_registered(controller.handle)
+
+        router.routes.clear()  # drop the Route's strong ref to the bound method
+        gc.collect()
+        assert not is_route_registered(controller.handle)  # entry gone
 
     def test_unregistered_bound_method_is_not_flagged(self):
         class Controller:


### PR DESCRIPTION
## The High (Codex, commit 4714ebc)

The `id()`-keyed route-registered registry — added last round to fix the *unhashable-handler* Medium — could not match a **fresh** `obj.method` access. Python builds a new bound-method object on every `obj.method` access, so:

```python
app.router.add_route("/secret", c.secret, public=True)   # registers obj-A
require_auth(c.secret)                                    # fresh access = obj-B
# is_route_registered(obj-B) → False → guard doesn't fire → require_auth() proceeds,
# but the route still dispatches obj-A unauthenticated
```

Reproduced: unauthenticated `GET /secret` → **200 with protected data**. The previous `WeakSet` caught this (bound methods compare by `(instance, func)`); the `id()` switch lost it. A warning is not a security control, so this needed an actual fix.

## The fix: one registry, two scalpels

`_route_registry_key()` keys the **single** `WeakValueDictionary` by **logical identity**:
- `(id(instance), id(function))` for bound methods → stable across fresh accesses → the guard fires;
- `id()` for everything else → strict identity, guards id-reuse.

This is a strict **superset** of both prior approaches: it catches fresh bound-method accesses (**closes this High**) *and* tracks unhashable callables (**keeps the earlier Medium closed**) — no second registry, no `WeakSet`+`id` dual.

Value-equality is safe here because this registry only feeds the **fail-loud** order guard (an over-match can only raise spuriously, never let a route through). The secured marker deliberately stays **strict-`id` only**, so a value-equal callable can't launder the auth posture.

## Verification
- Scanner PoC now fails closed (`require_auth` on a fresh access raises).
- Other-instance-same-method correctly does **not** match (keying is per-instance).
- GC edges: entry survives while the route holds the handler; self-cleans after.
- Mutation test: reverting to `id()`-only turns the fresh-access tests red.
- Removed the obsolete bound-method warning (we track, not warn).
- **1278 passing.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified 2.0.0 breaking-change notes explaining route security guard behavior and limitations with bound methods.

* **Bug Fixes**
  * Improved route decorator-order guard to correctly recognize fresh accesses to registered bound methods.

* **Tests**
  * Enhanced coverage for bound-method route registration and security decorator ordering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->