### PR TITLE
Fix integer field arg bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### ORM
+
+- `IntegerField` once again accepts the legacy positional `Field` arguments
+  (`default`, `null`, `unique`, `primary_key`) for backward compatibility.
+- `index` should now be passed explicitly as a keyword: `IntegerField(index=True)`.
+  The ambiguous form `IntegerField(True)` is interpreted as `default=True`, matching
+  the base `Field` positional contract.
+
 ## 2.0.0 — Default-deny route security
 
 ### ⚠️ Breaking change: routes must declare their access posture

--- a/kinglet/orm.py
+++ b/kinglet/orm.py
@@ -124,7 +124,7 @@ class IntegerField(Field):
 
         field_arg_names = ("default", "null", "unique", "primary_key")
         field_kwargs = dict(kwargs)
-        for name, value in zip(field_arg_names, args, strict=False):
+        for name, value in zip(field_arg_names, args):
             if name in field_kwargs:
                 raise TypeError(
                     f"{name} provided both positionally and by keyword"

--- a/kinglet/orm.py
+++ b/kinglet/orm.py
@@ -116,23 +116,22 @@ class IntegerField(Field):
     def __init__(
         self,
         *args: Any,
-        default: Any = None,
-        index: bool | None = None,
-        **kwargs,
-    ):
-        if len(args) > 1:
-            raise TypeError("IntegerField accepts at most one positional argument")
-        if args:
-            positional = args[0]
-            if isinstance(positional, bool) and default is None and index is None:
-                index = positional
-            elif default is None:
-                default = positional
-            else:
-                raise TypeError("default provided both positionally and by keyword")
-        if index is None:
-            index = False
-        super().__init__(default=default, **kwargs)
+        index: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        if len(args) > 4:
+            raise TypeError("IntegerField accepts at most four positional arguments")
+
+        field_arg_names = ("default", "null", "unique", "primary_key")
+        field_kwargs = dict(kwargs)
+        for name, value in zip(field_arg_names, args, strict=False):
+            if name in field_kwargs:
+                raise TypeError(
+                    f"{name} provided both positionally and by keyword"
+                )
+            field_kwargs[name] = value
+
+        super().__init__(**field_kwargs)
         self.index = index  # Explicit indexing control
 
     def to_python(self, value: Any) -> int | None:

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -126,6 +126,16 @@ class TestFieldValidation:
             ((1, 2, 3, 4, 5), {}, "at most four positional arguments"),
             ((5,), {"default": 3}, "default provided both positionally and by keyword"),
             ((5, False), {"null": True}, "null provided both positionally and by keyword"),
+            (
+                (1, False, True),
+                {"unique": False},
+                "unique provided both positionally and by keyword",
+            ),
+            (
+                (1, False, True, True),
+                {"primary_key": False},
+                "primary_key provided both positionally and by keyword",
+            ),
         ],
     )
     def test_integer_field_rejects_invalid_positional_arguments(

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -97,20 +97,35 @@ class TestFieldValidation:
         assert field.default == 7
         assert field.index is False
 
-    def test_integer_field_boolean_defaults_are_preserved(self):
-        indexed_field = IntegerField(True)
-        explicit_default = IntegerField(default=True)
+    def test_integer_field_positional_field_arguments_are_forwarded(self):
+        field = IntegerField(1, False, True, True, index=True)
 
-        assert indexed_field.default is None
-        assert indexed_field.index is True
-        assert explicit_default.default is True
-        assert explicit_default.index is False
+        assert field.default == 1
+        assert field.null is False
+        assert field.unique is True
+        assert field.primary_key is True
+        assert field.index is True
+
+    def test_integer_field_positional_boolean_default_is_preserved(self):
+        field = IntegerField(True)
+
+        assert field.default is True
+        assert field.index is False
+
+    def test_integer_field_positional_default_is_used_by_model_instances(self):
+        class LegacyModel(Model):
+            score = IntegerField(7)
+
+        instance = LegacyModel()
+
+        assert instance.score == 7
 
     @pytest.mark.parametrize(
         "args, kwargs, message",
         [
-            ((1, 2), {}, "at most one positional argument"),
+            ((1, 2, 3, 4, 5), {}, "at most four positional arguments"),
             ((5,), {"default": 3}, "default provided both positionally and by keyword"),
+            ((5, False), {"null": True}, "null provided both positionally and by keyword"),
         ],
     )
     def test_integer_field_rejects_invalid_positional_arguments(

--- a/tests/test_orm_field_edge_cases.py
+++ b/tests/test_orm_field_edge_cases.py
@@ -203,10 +203,10 @@ class TestFieldIndexConfiguration:
         field = IntegerField(index=True)
         assert field.index is True
 
-        # Backward-compatible positional boolean still maps to index
+        # Positional boolean remains a default value for backward compatibility
         field = IntegerField(True)
-        assert field.index is True
-        assert field.default is None
+        assert field.index is False
+        assert field.default is True
 
         # Index with other options
         field = IntegerField(index=True, primary_key=True)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored IntegerField support for legacy positional arguments (default, null, unique, primary_key).

* **Documentation**
  * Updated IntegerField documentation with clarified behavior: index parameter must be explicitly passed as a keyword argument; positional boolean values are interpreted as the default parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->